### PR TITLE
fixes tests to work with ioredis as default driver

### DIFF
--- a/test/acceptance/coffee/ApplyingUpdatesToADocTests.coffee
+++ b/test/acceptance/coffee/ApplyingUpdatesToADocTests.coffee
@@ -38,6 +38,7 @@ describe "Applying updates to a doc", ->
 			DocUpdaterClient.sendUpdate @project_id, @doc_id, @update, (error) ->
 				throw error if error?
 				setTimeout done, 200
+			return null
 
 		after ->
 			MockWebApi.getDocument.restore()
@@ -46,11 +47,13 @@ describe "Applying updates to a doc", ->
 			MockWebApi.getDocument
 				.calledWith(@project_id, @doc_id)
 				.should.equal true
+			return null
 
 		it "should update the doc", (done) ->
 			DocUpdaterClient.getDoc @project_id, @doc_id, (error, res, doc) =>
 				doc.lines.should.deep.equal @result
 				done()
+			return null
 
 		it "should push the applied updates to the track changes api", (done) ->
 			rclient_history.lrange HistoryKeys.uncompressedHistoryOps({@doc_id}), 0, -1, (error, updates) =>
@@ -60,12 +63,16 @@ describe "Applying updates to a doc", ->
 					throw error if error?
 					result.should.equal 1
 					done()
+			return null
+
+
 
 		it "should push the applied updates to the project history changes api", (done) ->
 			rclient_history.lrange ProjectHistoryKeys.projectHistoryOps({@project_id}), 0, -1, (error, updates) =>
 				throw error if error?
 				JSON.parse(updates[0]).op.should.deep.equal @update.op
 				done()
+			return null
 
 		it "should set the first op timestamp", (done) ->
 			rclient_history.get ProjectHistoryKeys.projectHistoryFirstOpTimestamp({@project_id}), (error, result) =>
@@ -73,6 +80,7 @@ describe "Applying updates to a doc", ->
 				result.should.be.within(@startTime, Date.now())
 				@firstOpTimestamp = result
 				done()
+			return null
 
 		describe "when sending another update", ->
 			before (done) ->
@@ -81,6 +89,7 @@ describe "Applying updates to a doc", ->
 				DocUpdaterClient.sendUpdate @project_id, @doc_id, @second_update, (error) ->
 					throw error if error?
 					setTimeout done, 200
+			return null
 
 			it "should not change the first op timestamp", (done) ->
 				rclient_history.get ProjectHistoryKeys.projectHistoryFirstOpTimestamp({@project_id}), (error, result) =>
@@ -99,6 +108,7 @@ describe "Applying updates to a doc", ->
 				DocUpdaterClient.sendUpdate @project_id, @doc_id, @update, (error) ->
 					throw error if error?
 					setTimeout done, 200
+			return null
 
 		after ->
 			MockWebApi.getDocument.restore()
@@ -110,6 +120,7 @@ describe "Applying updates to a doc", ->
 			DocUpdaterClient.getDoc @project_id, @doc_id, (error, res, doc) =>
 				doc.lines.should.deep.equal @result
 				done()
+			return null
 
 		it "should push the applied updates to the track changes api", (done) ->
 			rclient_history.lrange HistoryKeys.uncompressedHistoryOps({@doc_id}), 0, -1, (error, updates) =>
@@ -117,12 +128,14 @@ describe "Applying updates to a doc", ->
 				rclient_history.sismember HistoryKeys.docsWithHistoryOps({@project_id}), @doc_id, (error, result) =>
 					result.should.equal 1
 					done()
+			return null
+
 
 		it "should push the applied updates to the project history changes api", (done) ->
 			rclient_history.lrange ProjectHistoryKeys.projectHistoryOps({@project_id}), 0, -1, (error, updates) =>
 				JSON.parse(updates[0]).op.should.deep.equal @update.op
 				done()
-
+			return null
 
 	describe "when the document has been deleted", ->
 		describe "when the ops come in a single linear order", ->
@@ -161,6 +174,7 @@ describe "Applying updates to a doc", ->
 					DocUpdaterClient.getDoc @project_id, @doc_id, (error, res, doc) =>
 						doc.lines.should.deep.equal @my_result
 						done()
+				return null
 
 			it "should push the applied updates to the track changes api", (done) ->
 				rclient_history.lrange HistoryKeys.uncompressedHistoryOps({@doc_id}), 0, -1, (error, updates) =>
@@ -171,6 +185,8 @@ describe "Applying updates to a doc", ->
 					rclient_history.sismember HistoryKeys.docsWithHistoryOps({@project_id}), @doc_id, (error, result) =>
 						result.should.equal 1
 						done()
+				return null
+
 
 			it "should store the doc ops in the correct order", (done) ->
 				rclient_du.lrange Keys.docOps({doc_id: @doc_id}), 0, -1, (error, updates) =>
@@ -178,6 +194,7 @@ describe "Applying updates to a doc", ->
 					for appliedUpdate, i in @updates
 						appliedUpdate.op.should.deep.equal updates[i].op
 					done()
+				return null
 
 		describe "when older ops come in after the delete", ->
 			before (done) ->
@@ -222,6 +239,7 @@ describe "Applying updates to a doc", ->
 			DocUpdaterClient.sendUpdate @project_id, @doc_id, @broken_update, (error) ->
 				throw error if error?
 				setTimeout done, 200
+			return null
 
 		it "should not update the doc", (done) ->
 			DocUpdaterClient.getDoc @project_id, @doc_id, (error, res, doc) =>
@@ -261,6 +279,7 @@ describe "Applying updates to a doc", ->
 			async.series actions, (error) =>
 				throw error if error?
 				setTimeout done, 2000
+			return null
 
 		after ->
 			MockTrackChangesApi.flushDoc.restore()
@@ -282,6 +301,7 @@ describe "Applying updates to a doc", ->
 			DocUpdaterClient.sendUpdate @project_id, @doc_id, update, (error) ->
 				throw error if error?
 				setTimeout done, 200
+			return null
 
 		it "should update the doc (using version = 0)", (done) ->
 			DocUpdaterClient.getDoc @project_id, @doc_id, (error, res, doc) =>
@@ -322,6 +342,7 @@ describe "Applying updates to a doc", ->
 						throw error if error?
 						setTimeout done, 200
 				, 200
+			return null
 
 		it "should update the doc", (done) ->
 			DocUpdaterClient.getDoc @project_id, @doc_id, (error, res, doc) =>

--- a/test/acceptance/coffee/ApplyingUpdatesToProjectStructureTests.coffee
+++ b/test/acceptance/coffee/ApplyingUpdatesToProjectStructureTests.coffee
@@ -42,6 +42,8 @@ describe "Applying updates to a project's structure", ->
 				update.version.should.equal "#{@version}.0"
 
 				done()
+			return null
+
 
 	describe "renaming a document", ->
 		before ->
@@ -71,6 +73,7 @@ describe "Applying updates to a project's structure", ->
 					update.version.should.equal "#{@version}.0"
 
 					done()
+				return null
 
 		describe "when the document is loaded", ->
 			before (done) ->
@@ -90,6 +93,7 @@ describe "Applying updates to a project's structure", ->
 				DocUpdaterClient.getDoc @project_id, @docUpdate.id, (error, res, doc) =>
 					doc.pathname.should.equal @docUpdate.newPathname
 					done()
+				return null
 
 			it "should push the applied doc renames to the project history api", (done) ->
 				rclient_history.lrange ProjectHistoryKeys.projectHistoryOps({@project_id}), 0, -1, (error, updates) =>
@@ -104,6 +108,7 @@ describe "Applying updates to a project's structure", ->
 					update.version.should.equal "#{@version}.0"
 
 					done()
+				return null
 
 	describe "renaming multiple documents and files", ->
 		before ->
@@ -132,6 +137,7 @@ describe "Applying updates to a project's structure", ->
 				DocUpdaterClient.sendProjectUpdate @project_id, @user_id, @docUpdates, @fileUpdates, @version, (error) ->
 					throw error if error?
 					setTimeout done, 200
+				return null
 
 			it "should push the applied doc renames to the project history api", (done) ->
 				rclient_history.lrange ProjectHistoryKeys.projectHistoryOps({@project_id}), 0, -1, (error, updates) =>
@@ -170,6 +176,7 @@ describe "Applying updates to a project's structure", ->
 					update.version.should.equal "#{@version}.3"
 
 					done()
+				return null
 
 
 	describe "adding a file", ->
@@ -197,6 +204,7 @@ describe "Applying updates to a project's structure", ->
 				update.version.should.equal "#{@version}.0"
 
 				done()
+			return null
 
 	describe "adding a doc", ->
 		before (done) ->
@@ -223,6 +231,7 @@ describe "Applying updates to a project's structure", ->
 				update.version.should.equal "#{@version}.0"
 
 				done()
+			return null
 
 	describe "with enough updates to flush to the history service", ->
 		before (done) ->

--- a/test/acceptance/coffee/SettingADocumentTests.coffee
+++ b/test/acceptance/coffee/SettingADocumentTests.coffee
@@ -75,6 +75,7 @@ describe "Setting a document", ->
 				throw error if error?
 				expect(JSON.parse(lines)).to.deep.equal @newLines
 				done()
+			return null
 
 	describe "when the updated doc does not exist in the doc updater", ->
 		before (done) ->
@@ -103,6 +104,7 @@ describe "Setting a document", ->
 				throw error if error?
 				expect(lines).to.not.exist
 				done()
+			return null
 
 	describe "with track changes", ->
 		before ->


### PR DESCRIPTION
because ioredis returns a promise it can cause issues in mocha,
could have changed the implementation to stop the returning of the
redis client but decided against that, unsure if good call

sharelatex/redis-sharelatex#8


replaces https://github.com/sharelatex/document-updater-sharelatex-internal/pull/52