### PR TITLE
[redis] use the correct instance for the real time updates

### DIFF
--- a/test/unit/coffee/DispatchManager/DispatchManagerTests.coffee
+++ b/test/unit/coffee/DispatchManager/DispatchManagerTests.coffee
@@ -13,7 +13,7 @@ describe "DispatchManager", ->
 			"logger-sharelatex": @logger = { log: sinon.stub(), error: sinon.stub(), warn: sinon.stub() }
 			"settings-sharelatex": @settings =
 				redis:
-					realtime: {}
+					documentupdater: {}
 			"redis-sharelatex": @redis = {}
 			"./RateLimitManager": {}
 			"./Errors": Errors


### PR DESCRIPTION
The real-time service pushes pending changes [0] into the document-updater redis instance [1], while the document-updater pulls [2] them from the real-time redis instance [3].

This causes the editor to become read-only. After making changes to a document the editor tries to save these, but the operation times out, resulting in a force reload.

You may have some rational on where the updates should actually be stored, reverting these commits was the easiest fix here.

cc @henryoswald who committed the reverts previously.

---
[0] https://github.com/overleaf/real-time/blob/8b95f6369bb199c71350e548942384940cc0f377/app/coffee/DocumentUpdaterManager.coffee#L66
[1] https://github.com/overleaf/real-time/blob/8b95f6369bb199c71350e548942384940cc0f377/app/coffee/DocumentUpdaterManager.coffee#L6
[2] https://github.com/overleaf/document-updater/blob/eb2472a572c63c1af9abbc76f4c82cb466db6e18/app/coffee/DispatchManager.coffee#L18
[3] https://github.com/overleaf/document-updater/blob/eb2472a572c63c1af9abbc76f4c82cb466db6e18/app/coffee/DispatchManager.coffee#L13