### PR TITLE
[redis] use the correct instance for the history updates

### DIFF
--- a/app/coffee/ProjectHistoryRedisManager.coffee
+++ b/app/coffee/ProjectHistoryRedisManager.coffee
@@ -1,6 +1,6 @@
 Settings = require('settings-sharelatex')
 projectHistoryKeys = Settings.redis?.project_history?.key_schema
-rclient = require("redis-sharelatex").createClient(Settings.redis.documentupdater)
+rclient = require("redis-sharelatex").createClient(Settings.redis.project_history)
 logger = require('logger-sharelatex')
 
 module.exports = ProjectHistoryRedisManager =


### PR DESCRIPTION
Similar to #65 .

The project history tab in the editor remains empty when using more than one redis instance.

The following keys are related to the history and are currently written into/read from the `documentupdater` redis instance instead of the `history` one.

Key | refs | location 
--- | --- | --- 
`UncompressedHistoryOps` | track-changes [0][1] | app and tests
`ProjectHistory:Ops` | - | app
`ProjectHistory:FirstOpTimestamp` | - | app 

The second and third keys are not pulled in the CE code, you may find some references in the `project-history` project.

---

[0] https://github.com/overleaf/track-changes/blob/39c789477d6cec95018058c34ce7b01a54540bbf/app/coffee/RedisManager.coffee#L3
[1] https://github.com/overleaf/track-changes/blob/39c789477d6cec95018058c34ce7b01a54540bbf/app/coffee/RedisManager.coffee#L77 