### PR TITLE
fix hash check

### DIFF
--- a/app/coffee/ShareJsUpdateManager.coffee
+++ b/app/coffee/ShareJsUpdateManager.coffee
@@ -26,7 +26,7 @@ module.exports = ShareJsUpdateManager =
 		logger.log project_id: project_id, doc_id: doc_id, update: update, "applying sharejs updates"
 		jobs = []
 		# record the update version before it is modified
-		incomingUpdateVersion = update.version
+		incomingUpdateVersion = update.v
 		# We could use a global model for all docs, but we're hitting issues with the
 		# internal state of ShareJS not being accessible for clearing caches, and
 		# getting stuck due to queued callbacks (line 260 of sharejs/server/model.coffee)


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

I found a bug in the hash check while working on https://github.com/overleaf/web-internal/pull/1853, it was using a non-existent `version` property instead of the correct `v` property, so it was silently skipping the check. I think I must have introduced this when cleaning up the variable names.  I've fixed it and added a unit test for the hash check.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/web-internal/pull/1853
Original PR that introduced the bug https://github.com/overleaf/issues/issues/1738

### Review

Fix typo, the update uses the `v` property for the version, not `version`.

#### Potential Impact

Low

#### Manual Testing Performed

- [x] unit test
- [x] tested in local dev env

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

Docupdater dashboard in grafana

#### Who Needs to Know?

@henryoswald @jdleesmiller 