### PR TITLE
add metric for invalid hash and other sharejs errors

### DIFF
--- a/app/coffee/ShareJsUpdateManager.coffee
+++ b/app/coffee/ShareJsUpdateManager.coffee
@@ -48,6 +48,7 @@ module.exports = ShareJsUpdateManager =
 					error = new Errors.DeleteMismatchError("Delete component does not match")
 					return callback(error)
 				else
+					metrics.inc "sharejs.other-error"
 					return callback(error)
 			logger.log project_id: project_id, doc_id: doc_id, error: error, "applied update"
 			model.getSnapshot doc_key, (error, data) =>
@@ -55,7 +56,11 @@ module.exports = ShareJsUpdateManager =
 				# only check hash when present and no other updates have been applied 
 				if update.hash? and incomingUpdateVersion == version
 					ourHash = ShareJsUpdateManager._computeHash(data.snapshot)
-					return callback(new Error("Invalid hash")) if ourHash != update.hash
+					if ourHash != update.hash
+						metrics.inc "sharejs.hash-fail"
+						return callback(new Error("Invalid hash"))
+					else
+						metrics.inc "sharejs.hash-pass", 0.001
 				docLines = data.snapshot.split(/\r\n|\n|\r/)
 				callback(null, docLines, data.v, model.db.appliedOps[doc_key] or [])
 


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Adds metric `sharejs.hash-fail` for hash failures in docupdater, as well as a metric for the overall rate `sharejs.hash-pass` (downsampled 1000x due to the high number of operations)

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/web-internal/pull/1853

### Review

Small change

#### Potential Impact

Metrics only, and downsampled on high rate.

#### Manual Testing Performed

- [x] Unit tests
- [x] Test in local dev env

#### Accessibility

NA

### Deployment

NA


#### Deployment Checklist

- [ ]  Add to grafana dashboard

#### Metrics and Monitoring

Grafana docupdater dashboard

#### Who Needs to Know?

@henryoswald @jdleesmiller 
