### PR TITLE
return failed and succesfully flushed projects when flushing everything

### DIFF
--- a/app/coffee/ProjectFlusher.coffee
+++ b/app/coffee/ProjectFlusher.coffee
@@ -56,8 +56,15 @@ ProjectFlusher =
 			jobs = _.map project_ids, (project_id)->
 				return (cb)->
 					ProjectManager.flushAndDeleteProjectWithLocks project_id, cb
-			async.parallelLimit jobs, options.concurrency, (error)->
-				return callback(error, project_ids)
+			async.parallelLimit async.reflectAll(jobs), options.concurrency, (error, results)->
+				success = []
+				failure = []
+				_.each results, (result, i)->
+					if result.error?
+						failure.push(project_ids[i])
+					else 
+						success.push(project_ids[i])
+				return callback(error, {success:success, failure:failure})
 
 
 module.exports = ProjectFlusher


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description
when hitting `curl localhost:3003/flush_all_projects` if a single project errors a 500 is returned and project further down are not processed. This PR will swallow the flush error and continue on while reporting the problem project id's back in the http response.


#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
