### PR TITLE
skip hash check when non-BMP characters replaced

### DIFF
--- a/app/coffee/UpdateManager.coffee
+++ b/app/coffee/UpdateManager.coffee
@@ -138,10 +138,13 @@ module.exports = UpdateManager =
 		# 16-bit character of a blackboard bold character (http://www.fileformat.info/info/unicode/char/1d400/index.htm).
 		# Something must be going on client side that is screwing up the encoding and splitting the
 		# two 16-bit characters so that \uD835 is standalone.
+		BAD_CHAR_REGEXP = /[\uD800-\uDFFF]/g
 		for op in update.op or []
-			if op.i?
+			if op.i? && BAD_CHAR_REGEXP.test(op.i)
 				# Replace high and low surrogate characters with 'replacement character' (\uFFFD)
-				op.i = op.i.replace(/[\uD800-\uDFFF]/g, "\uFFFD")
+				op.i = op.i.replace(BAD_CHAR_REGEXP, "\uFFFD")
+				# remove any client-side hash because we have modified the content
+				delete update.hash
 		return update
 
 	_addProjectHistoryMetadataToOps: (updates, pathname, projectHistoryId, lines) ->

--- a/test/unit/coffee/UpdateManager/UpdateManagerTests.coffee
+++ b/test/unit/coffee/UpdateManager/UpdateManagerTests.coffee
@@ -212,7 +212,7 @@ describe "UpdateManager", ->
 
 		describe "with UTF-16 surrogate pairs in the update", ->
 			beforeEach ->
-				@update = {op: [{p: 42, i: "\uD835\uDC00"}]}
+				@update = {op: [{p: 42, i: "\uD835\uDC00"}], hash: "f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"}
 				@UpdateManager.applyUpdate @project_id, @doc_id, @update, @callback
 
 			it "should apply the update but with surrogate pairs removed", ->
@@ -222,6 +222,9 @@ describe "UpdateManager", ->
 
 				# \uFFFD is 'replacement character'
 				@update.op[0].i.should.equal "\uFFFD\uFFFD"
+
+			it "should skip the hash check by removing any hash field present", ->
+				@update.should.not.have.property('hash')
 
 		describe "with an error", ->
 			beforeEach ->


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

When we strip out non-BMP characters in docupdater we should skip any hash check because we know that the document has changed and the hash from the client is therefore invalid.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/1738
https://github.com/overleaf/web-internal/issues/1911
https://github.com/overleaf/issues/issues/2005

### Review

I've moved the regex into a variable as we now need to test for the presence of the non-BMP characters, rather than just replacing them.

#### Potential Impact

Should only affect documents containing non-BMP characters.

#### Manual Testing Performed

- [x] Unit and acceptance tests
- [x] Test in local dev env

#### Accessibility

NA

### Deployment

Deploy to sl-lin-prod-web-0 first before deploying to all docupdaters.

#### Deployment Checklist

- [ ] Check that docupdater rate is normal after deployment: 

#### Metrics and Monitoring

Hash error rate should drop after excluding non-BMP characters:
http://grafana.sharelatex.com:8080/dashboard/db/document-updater?refresh=30s&panelId=18&fullscreen&edit&orgId=1&from=now-7d&to=now

It has already dropped on 27 June when https://github.com/overleaf/web-internal/issues/1911 was deployed to replace these characters when they are input in ace.

#### Who Needs to Know?

@jdleesmiller 