### PR TITLE
Revert "skip hash check when non-BMP characters replaced"

### DIFF
--- a/app/coffee/UpdateManager.coffee
+++ b/app/coffee/UpdateManager.coffee
@@ -138,13 +138,10 @@ module.exports = UpdateManager =
 		# 16-bit character of a blackboard bold character (http://www.fileformat.info/info/unicode/char/1d400/index.htm).
 		# Something must be going on client side that is screwing up the encoding and splitting the
 		# two 16-bit characters so that \uD835 is standalone.
-		BAD_CHAR_REGEXP = /[\uD800-\uDFFF]/g
 		for op in update.op or []
-			if op.i? && BAD_CHAR_REGEXP.test(op.i)
+			if op.i?
 				# Replace high and low surrogate characters with 'replacement character' (\uFFFD)
-				op.i = op.i.replace(BAD_CHAR_REGEXP, "\uFFFD")
-				# remove any client-side hash because we have modified the content
-				delete update.hash
+				op.i = op.i.replace(/[\uD800-\uDFFF]/g, "\uFFFD")
 		return update
 
 	_addProjectHistoryMetadataToOps: (updates, pathname, projectHistoryId, lines) ->

--- a/test/unit/coffee/UpdateManager/UpdateManagerTests.coffee
+++ b/test/unit/coffee/UpdateManager/UpdateManagerTests.coffee
@@ -212,7 +212,7 @@ describe "UpdateManager", ->
 
 		describe "with UTF-16 surrogate pairs in the update", ->
 			beforeEach ->
-				@update = {op: [{p: 42, i: "\uD835\uDC00"}], hash: "f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"}
+				@update = {op: [{p: 42, i: "\uD835\uDC00"}]}
 				@UpdateManager.applyUpdate @project_id, @doc_id, @update, @callback
 
 			it "should apply the update but with surrogate pairs removed", ->
@@ -222,9 +222,6 @@ describe "UpdateManager", ->
 
 				# \uFFFD is 'replacement character'
 				@update.op[0].i.should.equal "\uFFFD\uFFFD"
-
-			it "should skip the hash check by removing any hash field present", ->
-				@update.should.not.have.property('hash')
 
 		describe "with an error", ->
 			beforeEach ->


### PR DESCRIPTION
Reverts overleaf/document-updater#73

It doesn't work as intended. The hash check generates an out of sync error, which is what we want. If the hash check is disabled, you get the out of sync error some time later. What we need is a mechanism to trigger the 'out of sync' error on non-BMP character replacement which is distinct from the hash check.