### PR TITLE
support per-doc pubsub channels

### DIFF
--- a/app/coffee/RealTimeRedisManager.coffee
+++ b/app/coffee/RealTimeRedisManager.coffee
@@ -38,7 +38,7 @@ module.exports = RealTimeRedisManager =
 		data?._id = message_id
 		# publish on separate channels for individual projects and docs when
 		# configured (needs realtime to be configured for this too).
-		if Settings.publishOnIndividualChannels and data.doc_id?
+		if Settings.publishOnIndividualChannels
 			pubsubClient.publish "applied-ops:#{data.doc_id}", JSON.stringify(data)
 		else
 			pubsubClient.publish "applied-ops", JSON.stringify(data)

--- a/app/coffee/RealTimeRedisManager.coffee
+++ b/app/coffee/RealTimeRedisManager.coffee
@@ -36,4 +36,9 @@ module.exports = RealTimeRedisManager =
 		# create a unique message id using a counter
 		message_id = "doc:#{HOST}:#{RND}-#{COUNT++}"
 		data?._id = message_id
-		pubsubClient.publish "applied-ops", JSON.stringify(data)
+		# publish on separate channels for individual projects and docs when
+		# configured (needs realtime to be configured for this too).
+		if Settings.publishOnIndividualChannels and data.doc_id?
+			pubsubClient.publish "applied-ops:#{data.doc_id}", JSON.stringify(data)
+		else
+			pubsubClient.publish "applied-ops", JSON.stringify(data)

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -92,3 +92,5 @@ module.exports =
 
 	sentry:
 		dsn: process.env.SENTRY_DSN
+
+	publishOnIndividualChannels: process.env['PUBLISH_ON_INDIVIDUAL_CHANNELS'] or false


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

This PR adds a setting `publishOnIndividualChannels` for per-doc messages on the `applied-ops` channel from docupdater.  It will need to be enabled in the chef and google-ops configs.

#### Screenshots

NA

#### Related Issues / PRs

overleaf/real-time#65

### Review

Setting only, see overleaf/real-time#65 for the receiving side.

#### Potential Impact

High if setting is enabled (see deployment notes below), otherwise no effect.

#### Manual Testing Performed

- [X] Unit and acceptance tests
- [X] Local dev env

#### Accessibility

NA

### Deployment

Do not deploy without the overleaf/real-time#65 being fulled deployed with all clients drained from the old deploy.  Otherwise ops will never be acknowledged and the editor will break for everyone.

#### Deployment Checklist

- [x]  Ensure realtime fully drained and listening on the new channels.  Go onto redis and use the `PUBSUB CHANNELS` command to see that there are real-time processes listening on channels like `applied-ops:DOC_ID`
- [ ] Deploy a single instance of docupdater with the new setting `publishOnIndividualChannels: true`
- [ ] Connect to redis and subscribe using a pattern to see the per-doc applied-ops traffic: `PSUBSCRIBE applied-ops:*`
- [ ] Allow to run for at least 5 minutes, check that the editor does not break and metrics are normal
- [ ] Finish deploy

#### Metrics and Monitoring

- [ ] Monitor redis cpu in mmonit

#### Who Needs to Know?

@henryoswald 
