### PR TITLE
Don't log document lines in log messages

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -6,8 +6,9 @@ http = require("http")
 Settings = require('settings-sharelatex')
 logger = require('logger-sharelatex')
 logger.initialize("document-updater")
-logger.logger.serializers.docs = require("./app/js/LoggerSerializers").docs
-logger.logger.serializers.files = require("./app/js/LoggerSerializers").files
+
+logger.logger.addSerializers(require("./app/js/LoggerSerializers"))
+
 if Settings.sentry?.dsn?
 	logger.initializeErrorReporting(Settings.sentry.dsn)
 

--- a/app/coffee/LoggerSerializers.coffee
+++ b/app/coffee/LoggerSerializers.coffee
@@ -1,14 +1,10 @@
-module.exports =
-	docs: (docs) ->
-		docs.map (doc) ->
-			{
-				path: doc.path
-				id: doc.doc
-			}
+showLength = (thing) ->
+	"length: #{thing?.length}"
 
-	files: (files) ->
-		files.map (file) ->
-			{
-				path: file.path
-				id: file.file
-			}
+module.exports =
+	# replace long values with their length
+	lines: showLength
+	oldLines: showLength
+	newLines: showLength
+	ranges: showLength
+	update: showLength


### PR DESCRIPTION
### Description

Remove 'lines' field from log messages. It generates huge lines in the logs and makes grepping difficult.

I realise that this will be moot once we're at GKE, but I'm on support today and I'm finding this really unhelpful.

### Review

I thought it might be helpful to have data about `oldLines` and `newLines` when processing them, so I switched from logging the full contents, to just the length.

This is the only case in which I've changed something instead of removing it. I didn't want to crash with some form of "can't access lines of undefined", so I've checked this fairly thoroughly. - There is already a check further up in the method on `newLines?`, but I added a question-mark operator for `oldLines?` in the execution path in which it hadn't been checked for already. 

#### Potential Impact

As this just removes logging, it should be fairly minimal. I don't think that we use this data for anything.

#### Manual Testing Performed

- [x] Edited some documents