### PR TITLE
use MONGO_CONNECTION_STRING in settings.defaults.coffee if set

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -88,7 +88,7 @@ module.exports =
 	dispatcherCount: process.env["DISPATCHER_COUNT"]
 
 	mongo:
-		url: "mongodb://#{process.env["MONGO_HOST"] or "localhost"}/sharelatex"
+		url : process.env['MONGO_CONNECTION_STRING'] || "mongodb://#{process.env['MONGO_HOST'] or '127.0.0.1'}/sharelatex"
 
 	sentry:
 		dsn: process.env.SENTRY_DSN


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Settings.defaults.coffee needs to read in MONGO_CONNECTION_STRING for GKE config

#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
