### PR TITLE
Improve/fix serializers for update logging

### DIFF
--- a/app/coffee/LoggerSerializers.coffee
+++ b/app/coffee/LoggerSerializers.coffee
@@ -9,6 +9,7 @@ showUpdateLength = (update) ->
 		copy.op.forEach (element, index) ->
 			copy.op[index].i = element.i.length if element?.i?.length?
 			copy.op[index].d = element.d.length if element?.d?.length?
+			copy.op[index].c = element.c.length if element?.c?.length?
 		copy
 	else
 		update
@@ -18,5 +19,7 @@ module.exports =
 	lines: showLength
 	oldLines: showLength
 	newLines: showLength
+	docLines: showLength
+	newDocLines: showLength
 	ranges: showLength
 	update: showUpdateLength

--- a/app/coffee/LoggerSerializers.coffee
+++ b/app/coffee/LoggerSerializers.coffee
@@ -1,5 +1,17 @@
+_ = require('lodash')
+
 showLength = (thing) ->
-	"length: #{thing?.length}"
+	if thing?.length then thing.length else thing
+
+showUpdateLength = (update) ->
+	if update?.op instanceof Array
+		copy = _.cloneDeep(update)
+		copy.op.forEach (element, index) ->
+			copy.op[index].i = element.i.length if element?.i?.length?
+			copy.op[index].d = element.d.length if element?.d?.length?
+		copy
+	else
+		update
 
 module.exports =
 	# replace long values with their length
@@ -7,4 +19,4 @@ module.exports =
 	oldLines: showLength
 	newLines: showLength
 	ranges: showLength
-	update: showLength
+	update: showUpdateLength


### PR DESCRIPTION
### Description

Logging of `update` fields was broken by #78.

This PR adds a specific logger for `update`s, which are objects and don't have a `length`. Also fall back to returning the passed object if it doesn't look like the kind of thing we think it is.

#### Related Issues / PRs

Introduced in #78

### Review

Used `lodash` to duplicate the update objects before we modify, so we don't do something unexpected. It's in `package.json` already.

### Who needs to know

cc @henryoswald 