### PR TITLE
log the size of ops in an update

### DIFF
--- a/app/coffee/LoggerSerializers.coffee
+++ b/app/coffee/LoggerSerializers.coffee
@@ -1,10 +1,13 @@
 showLength = (thing) ->
 	"length: #{thing?.length}"
 
+showLengthOfUpdate = (update)->
+	"update op length: #{update?.op?.length}" 
+
 module.exports =
 	# replace long values with their length
 	lines: showLength
 	oldLines: showLength
 	newLines: showLength
 	ranges: showLength
-	update: showLength
+	update: showLengthOfUpdate


### PR DESCRIPTION
update is an object so .length doesn't return a value

<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description



#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
