### PR TITLE
add a combined health check for mongo and redis

### DIFF
--- a/app/coffee/mongojs.coffee
+++ b/app/coffee/mongojs.coffee
@@ -1,7 +1,12 @@
 Settings = require "settings-sharelatex"
 mongojs = require "mongojs"
 db = mongojs(Settings.mongo.url, ["docSnapshots"])
+
 module.exports =
 	db: db
 	ObjectId: mongojs.ObjectId
-
+	healthCheck: (callback) ->
+		db.runCommand {ping: 1}, (err, res) ->
+			return callback(err) if err?
+			return callback(new Error("failed mongo ping")) if !res.ok
+			callback()


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Adds a combined health check for mongo and redis under `/health_check`.  Existing health check urls are preserved, but they can be removed when the monitoring is updated to use the new combined health check.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2157

### Review

Small change

#### Potential Impact

Health checks, restarts process on failure.

#### Manual Testing Performed

- [X] curl http://localhost:3003/health_check in docker container (with valid and invalid mongo connection strings)

#### Accessibility

NA

### Deployment

Deploy first and monitor in production before enabling restart on failure.

#### Deployment Checklist

- [ ]  Add new health check url into monitoring configuration (google-ops and chef)

#### Metrics and Monitoring

NA

#### Who Needs to Know?

@henryoswald 