### PR TITLE
remove carriage-return on document load

### DIFF
--- a/app/coffee/PersistenceManager.coffee
+++ b/app/coffee/PersistenceManager.coffee
@@ -44,7 +44,7 @@ module.exports = PersistenceManager =
 					return callback(new Error("web API response had no valid doc version"))
 				if !body.pathname?
 					return callback(new Error("web API response had no valid doc pathname"))
-				# fix up any broken docs that are already in mongo
+				# fix up any broken docs that are already in mongo (overleaf/issues#2162)
 				PersistenceManager._fixInvalidLines(body.lines) # modifies body.lines array in-place
 				return callback null, body.lines, body.version, body.ranges, body.pathname, body.projectHistoryId
 			else if res.statusCode == 404

--- a/app/coffee/PersistenceManager.coffee
+++ b/app/coffee/PersistenceManager.coffee
@@ -54,7 +54,7 @@ module.exports = PersistenceManager =
 
 	_fixInvalidLines: (lines) ->
 		# trim any unwanted trailing '\r's from stored docs
-		matched = for line, i in lines when line.slice(-1) is '\r'
+		matched = for line, i in lines when line.endsWith('\r')
 			lines[i] = line.slice(0, -1)
 		Metrics.inc 'get-doc.replace-cr' if matched.length > 0
 

--- a/test/acceptance/coffee/GettingADocumentTests.coffee
+++ b/test/acceptance/coffee/GettingADocumentTests.coffee
@@ -9,7 +9,8 @@ DocUpdaterApp = require "./helpers/DocUpdaterApp"
 
 describe "Getting a document", ->
 	before (done) ->
-		@lines = ["one", "two", "three"]
+		@orig_lines = ["one", "two", "three", "four\r", "five"]
+		@lines = ["one", "two", "three", "four", "five"]
 		@version = 42
 		DocUpdaterApp.ensureRunning(done)
 
@@ -18,7 +19,7 @@ describe "Getting a document", ->
 			[@project_id, @doc_id] = [DocUpdaterClient.randomId(), DocUpdaterClient.randomId()]
 			sinon.spy MockWebApi, "getDocument"
 
-			MockWebApi.insertDoc @project_id, @doc_id, {lines: @lines, version: @version}
+			MockWebApi.insertDoc @project_id, @doc_id, {lines: @orig_lines, version: @version}
 
 			DocUpdaterClient.getDoc @project_id, @doc_id, (error, res, @returnedDoc) => done()
 

--- a/test/unit/coffee/PersistenceManager/PersistenceManagerTests.coffee
+++ b/test/unit/coffee/PersistenceManager/PersistenceManagerTests.coffee
@@ -15,11 +15,13 @@ describe "PersistenceManager", ->
 			"./Metrics": @Metrics =
 				Timer: class Timer
 					done: sinon.stub()
+				inc: sinon.stub()
 			"logger-sharelatex": @logger = {log: sinon.stub(), err: sinon.stub()}
 		@project_id = "project-id-123"
 		@projectHistoryId = "history-id-123"
 		@doc_id = "doc-id-123"
-		@lines = ["one", "two", "three"]
+		@orig_lines = ["one", "two", "three", "four\r"]
+		@lines = ["one", "two", "three", "four"]
 		@version = 42
 		@callback = sinon.stub()
 		@ranges = { comments: "mock", entries: "mock" }
@@ -35,7 +37,7 @@ describe "PersistenceManager", ->
 	describe "getDoc", ->
 		beforeEach ->
 			@webResponse = {
-				lines: @lines,
+				lines: @orig_lines,
 				version: @version,
 				ranges: @ranges
 				pathname: @pathname,


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Workaround for existing docs in mongo which contain spurious `\r` characters from incorrectly stripped `\r\n` line-endings due to https://github.com/overleaf/issues/issues/2162

The approach is to strip  `\r` characters at the end of any doc lines when loading them.  

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2162

### Review

Normally there could be a problem with modifying the document on load.  Consider a case where 2 users are editing a document.  If user A has already loaded the document with bad characters, and user B loads it later and the bad characters are stripped out, they will generate conflicting ops.

However, in this case we know that the editor is crashing on documents which have incorrectly stripped `\r\n` line endings so nobody can edit them and it is safe to add this workaround.

Dropbox and Git should already be removing `\r\n` line-endings so they should not cause an issue here.

Documents containing only `\r` characters will not be fixed by this problem as the `\r` will occur in the middle of a line,  the whole document would already be loading as a single line anyway.

#### Potential Impact

Only affects documents containing `\r` line-endings.

#### Manual Testing Performed

- [X] Unit and acceptance tests


#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [ ] Test loading https://www.overleaf.com/docs?snip_uri=http://www.texample.net/media/tikz/examples/TEX/nav1d.tex&splash=none
- [ ] Test another project, you can find examples with `db.docs.find({lines:/\r/}).sort({_id:-1})` - they are all from Open In Overleaf.

#### Metrics and Monitoring

New docupdater metric `get-doc.replace-cr`

#### Who Needs to Know?

@gh2k 