### PR TITLE
skip history flush when project is cleared by realtime shutdown

### DIFF
--- a/app/coffee/HistoryManager.coffee
+++ b/app/coffee/HistoryManager.coffee
@@ -28,6 +28,9 @@ module.exports = HistoryManager =
 	# flush changes and callback (for when we need to know the queue is flushed)
 	flushProjectChanges: (project_id, options, callback = (error) ->) ->
 		return callback() if !Settings.apis?.project_history?.enabled
+		if options.skip_history_flush
+			logger.log {project_id}, "skipping flush of project history from realtime shutdown"
+			return callback()
 		url = "#{Settings.apis.project_history.url}/project/#{project_id}/flush"
 		qs = {}
 		qs.background = true if options.background # pass on the background flush option if present

--- a/app/coffee/HttpController.coffee
+++ b/app/coffee/HttpController.coffee
@@ -133,6 +133,7 @@ module.exports = HttpController =
 		timer = new Metrics.Timer("http.deleteProject")
 		options = {}
 		options.background = true if req.query?.background # allow non-urgent flushes to be queued
+		options.skip_history_flush = true if req.query?.shutdown # don't flush history when realtime shuts down
 		ProjectManager.flushAndDeleteProjectWithLocks project_id, options, (error) ->
 			timer.done()
 			return next(error) if error?

--- a/test/acceptance/coffee/helpers/DocUpdaterClient.coffee
+++ b/test/acceptance/coffee/helpers/DocUpdaterClient.coffee
@@ -75,6 +75,9 @@ module.exports = DocUpdaterClient =
 	deleteProject: (project_id, callback = () ->) ->
 		request.del "http://localhost:3003/project/#{project_id}", callback
 
+	deleteProjectOnShutdown: (project_id, callback = () ->) ->
+		request.del "http://localhost:3003/project/#{project_id}?background=true&shutdown=true", callback
+
 	acceptChange: (project_id, doc_id, change_id, callback = () ->) ->
 		request.post "http://localhost:3003/project/#{project_id}/doc/#{doc_id}/change/#{change_id}/accept", callback
 

--- a/test/unit/coffee/HistoryManager/HistoryManagerTests.coffee
+++ b/test/unit/coffee/HistoryManager/HistoryManagerTests.coffee
@@ -46,6 +46,28 @@ describe "HistoryManager", ->
 				.calledWith({url: "#{@Settings.apis.project_history.url}/project/#{@project_id}/flush", qs:{background:true}})
 				.should.equal true
 
+	describe "flushProjectChanges", ->
+
+		describe "in the normal case", ->
+			beforeEach ->
+				@request.post = sinon.stub().callsArgWith(1, null, statusCode: 204)
+				@HistoryManager.flushProjectChanges @project_id, {background:true}
+
+			it "should send a request to the project history api", ->
+				@request.post
+					.calledWith({url: "#{@Settings.apis.project_history.url}/project/#{@project_id}/flush", qs:{background:true}})
+					.should.equal true
+
+		describe "with the skip_history_flush option", ->
+			beforeEach ->
+				@request.post = sinon.stub()
+				@HistoryManager.flushProjectChanges @project_id, {skip_history_flush:true}
+
+			it "should not send a request to the project history api", ->
+				@request.post
+					.called
+					.should.equal false
+
 	describe "recordAndFlushHistoryOps", ->
 		beforeEach ->
 			@ops = [ 'mock-ops' ]

--- a/test/unit/coffee/HttpController/HttpControllerTests.coffee
+++ b/test/unit/coffee/HttpController/HttpControllerTests.coffee
@@ -343,6 +343,17 @@ describe "HttpController", ->
 			it "should time the request", ->
 				@Metrics.Timer::done.called.should.equal true
 
+		describe "with the shutdown=true option from realtime", ->
+			beforeEach ->
+				@ProjectManager.flushAndDeleteProjectWithLocks = sinon.stub().callsArgWith(2)
+				@req.query = {background:true, shutdown:true}
+				@HttpController.deleteProject(@req, @res, @next)
+
+			it "should pass the skip_history_flush option when flushing the project", ->
+				@ProjectManager.flushAndDeleteProjectWithLocks
+					.calledWith(@project_id, {background:true, skip_history_flush:true})
+					.should.equal true
+
 		describe "when an errors occurs", ->
 			beforeEach ->
 				@ProjectManager.flushAndDeleteProjectWithLocks = sinon.stub().callsArgWith(2, new Error("oops"))


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

When realtime is shutting down it adds a `shutdown=true` parameter to the request to flush a project from docupdater.  In this case we want to avoid doing an extra flush to project history, to avoid a stampede.  The project history queues are cleared by a background cron job anyway.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/real-time/pull/70

### Review

Small change

#### Potential Impact

Low, skips flush to history only.  Documents are still pushed back to mongo and cleared from redis.


#### Manual Testing Performed

- [X] Unit and acceptance tests 
- [X] Test in local dev env

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?
