### PR TITLE
queue deletes for deferred processing

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -55,6 +55,7 @@ app.post   '/project/:project_id/doc/:doc_id',                          HttpCont
 app.post   '/project/:project_id/doc/:doc_id/flush',                    HttpController.flushDocIfLoaded
 app.delete '/project/:project_id/doc/:doc_id',                          HttpController.flushAndDeleteDoc
 app.delete '/project/:project_id',                                      HttpController.deleteProject
+app.delete '/project',                                                  HttpController.deleteMultipleProjects
 app.post   '/project/:project_id',                                      HttpController.updateProject
 app.post   '/project/:project_id/history/resync',                       HttpController.resyncProjectHistory
 app.post   '/project/:project_id/flush',                                HttpController.flushProject
@@ -63,6 +64,7 @@ app.post   '/project/:project_id/doc/:doc_id/change/accept',            HttpCont
 app.del    '/project/:project_id/doc/:doc_id/comment/:comment_id',      HttpController.deleteComment
 
 app.get    '/flush_all_projects',                                       HttpController.flushAllProjects
+app.get    '/flush_queued_projects', HttpController.flushQueuedProjects
 
 app.get '/total', (req, res)->
 	timer = new Metrics.Timer("http.allDocList")	

--- a/app/coffee/DeleteQueueManager.coffee
+++ b/app/coffee/DeleteQueueManager.coffee
@@ -31,7 +31,7 @@ module.exports = DeleteQueueManager =
                     logger.log {project_id}, "skipping flush of queued project - no timestamps"
                     return cb()
                 # are any of the timestamps newer than the time the project was flushed?
-                for timestamp in timestamps or [] when timestamp > flushTimestamp
+                for timestamp in timestamps when timestamp > flushTimestamp
                     metrics.inc "queued-delete-skipped"
                     logger.debug {project_id, timestamps, flushTimestamp}, "found newer timestamp, will skip delete"
                     return cb()

--- a/app/coffee/DeleteQueueManager.coffee
+++ b/app/coffee/DeleteQueueManager.coffee
@@ -1,0 +1,45 @@
+RedisManager = require "./RedisManager"
+ProjectManager = require "./ProjectManager"
+logger = require "logger-sharelatex"
+metrics = require "./Metrics"
+async = require "async"
+
+module.exports = DeleteQueueManager =
+    flushAndDeleteOldProjects: (options, callback) ->
+        startTime = Date.now()
+        count = 0
+
+        flushProjectIfNotModified = (project_id, flushTimestamp, cb) ->
+            ProjectManager.getProjectDocsTimestamps project_id, (err, timestamps) ->
+                return callback(err) if err?
+                if !timestamps?
+                    logger.log {project_id}, "skipping flush of queued project - no timestamps"
+                    return cb()
+                # are any of the timestamps newer than the time the project was flushed?
+                for timestamp in timestamps or [] when timestamp > flushTimestamp
+                    metrics.inc "queued-delete-skipped"
+                    logger.debug {project_id, timestamps, flushTimestamp}, "found newer timestamp, will skip delete"
+                    return cb()
+                logger.log {project_id, flushTimestamp}, "flushing queued project"
+                ProjectManager.flushAndDeleteProjectWithLocks project_id, {skip_history_flush: true}, (err) ->
+                    logger.err {project_id, err}, "error flushing queued project"
+                    metrics.inc "queued-delete-completed"
+                    return cb(null, true)
+
+        flushNextProject = () ->
+            now = Date.now()
+            if now - startTime > options.timeout
+                logger.log "hit time limit on flushing old projects"
+                return callback()
+            if count > options.limit
+                logger.log "hit count limit on flushing old projects"
+                return callback()
+            cutoffTime = now - options.min_delete_age 
+            RedisManager.getNextProjectToFlushAndDelete cutoffTime, (err, project_id, flushTimestamp) ->
+                return callback(err) if err?
+                return callback() if !project_id?
+                flushProjectIfNotModified project_id, flushTimestamp, (err, flushed) ->
+                    count++ if flushed
+                    flushNextProject()
+
+        flushNextProject()

--- a/app/coffee/DeleteQueueManager.coffee
+++ b/app/coffee/DeleteQueueManager.coffee
@@ -46,13 +46,13 @@ module.exports = DeleteQueueManager =
             now = Date.now()
             if now - startTime > options.timeout
                 logger.log "hit time limit on flushing old projects"
-                return callback()
+                return callback(null, count)
             if count > options.limit
                 logger.log "hit count limit on flushing old projects"
-                return callback()
+                return callback(null, count)
             RedisManager.getNextProjectToFlushAndDelete cutoffTime, (err, project_id, flushTimestamp, queueLength) ->
                 return callback(err) if err?
-                return callback() if !project_id?
+                return callback(null, count) if !project_id?
                 logger.log {project_id, queueLength: queueLength}, "flushing queued project"
                 metrics.globalGauge "queued-flush-backlog", queueLength
                 flushProjectIfNotModified project_id, flushTimestamp, (err, flushed) ->

--- a/app/coffee/DeleteQueueManager.coffee
+++ b/app/coffee/DeleteQueueManager.coffee
@@ -28,7 +28,7 @@ module.exports = DeleteQueueManager =
         flushProjectIfNotModified = (project_id, flushTimestamp, cb) ->
             ProjectManager.getProjectDocsTimestamps project_id, (err, timestamps) ->
                 return callback(err) if err?
-                if !timestamps?
+                if timestamps.length == 0
                     logger.log {project_id}, "skipping flush of queued project - no timestamps"
                     return cb()
                 # are any of the timestamps newer than the time the project was flushed?

--- a/app/coffee/DeleteQueueManager.coffee
+++ b/app/coffee/DeleteQueueManager.coffee
@@ -38,7 +38,8 @@ module.exports = DeleteQueueManager =
                     return cb()
                 logger.log {project_id, flushTimestamp}, "flushing queued project"
                 ProjectManager.flushAndDeleteProjectWithLocks project_id, {skip_history_flush: true}, (err) ->
-                    logger.err {project_id, err}, "error flushing queued project"
+                    if err?
+                        logger.err {project_id, err}, "error flushing queued project"
                     metrics.inc "queued-delete-completed"
                     return cb(null, true)
 

--- a/app/coffee/DeleteQueueManager.coffee
+++ b/app/coffee/DeleteQueueManager.coffee
@@ -22,6 +22,7 @@ async = require "async"
 module.exports = DeleteQueueManager =
     flushAndDeleteOldProjects: (options, callback) ->
         startTime = Date.now()
+        cutoffTime = startTime - options.min_delete_age 
         count = 0
 
         flushProjectIfNotModified = (project_id, flushTimestamp, cb) ->
@@ -49,7 +50,6 @@ module.exports = DeleteQueueManager =
             if count > options.limit
                 logger.log "hit count limit on flushing old projects"
                 return callback()
-            cutoffTime = now - options.min_delete_age 
             RedisManager.getNextProjectToFlushAndDelete cutoffTime, (err, project_id, flushTimestamp, queueLength) ->
                 return callback(err) if err?
                 return callback() if !project_id?

--- a/app/coffee/DeleteQueueManager.coffee
+++ b/app/coffee/DeleteQueueManager.coffee
@@ -35,9 +35,11 @@ module.exports = DeleteQueueManager =
                 logger.log "hit count limit on flushing old projects"
                 return callback()
             cutoffTime = now - options.min_delete_age 
-            RedisManager.getNextProjectToFlushAndDelete cutoffTime, (err, project_id, flushTimestamp) ->
+            RedisManager.getNextProjectToFlushAndDelete cutoffTime, (err, project_id, flushTimestamp, queueLength) ->
                 return callback(err) if err?
                 return callback() if !project_id?
+                logger.log {project_id, queueLength: queueLength}, "flushing queued project"
+                metrics.globalGauge "queued-flush-backlog", queueLength
                 flushProjectIfNotModified project_id, flushTimestamp, (err, flushed) ->
                     count++ if flushed
                     flushNextProject()

--- a/app/coffee/HistoryManager.coffee
+++ b/app/coffee/HistoryManager.coffee
@@ -29,7 +29,7 @@ module.exports = HistoryManager =
 	flushProjectChanges: (project_id, options, callback = (error) ->) ->
 		return callback() if !Settings.apis?.project_history?.enabled
 		if options.skip_history_flush
-			logger.log {project_id}, "skipping flush of project history from realtime shutdown"
+			logger.log {project_id}, "skipping flush of project history"
 			return callback()
 		url = "#{Settings.apis.project_history.url}/project/#{project_id}/flush"
 		qs = {}

--- a/app/coffee/HttpController.coffee
+++ b/app/coffee/HttpController.coffee
@@ -219,7 +219,6 @@ module.exports = HttpController =
 		options = 
 			limit : req.query.limit || 1000
 			timeout: 5 * 60 * 1000
-			dryRun : req.query.dryRun || false
 			min_delete_age: req.query.min_delete_age || 5 * 60 * 1000
 		res.send 204
 		# run the flush in the background

--- a/app/coffee/HttpController.coffee
+++ b/app/coffee/HttpController.coffee
@@ -216,14 +216,15 @@ module.exports = HttpController =
 				res.send project_ids
 
 	flushQueuedProjects: (req, res, next = (error) ->) ->
+		res.setTimeout(10 * 60 * 1000)
 		options = 
 			limit : req.query.limit || 1000
 			timeout: 5 * 60 * 1000
 			min_delete_age: req.query.min_delete_age || 5 * 60 * 1000
-		res.send 204
-		# run the flush in the background
 		DeleteQueueManager.flushAndDeleteOldProjects options, (err, flushed)->
 			if err?
 				logger.err err:err, "error flushing old projects"
-			else 
+				res.send 500
+			else
 				logger.log {flushed: flushed}, "flush of queued projects completed"
+				res.send {flushed: flushed}

--- a/app/coffee/HttpController.coffee
+++ b/app/coffee/HttpController.coffee
@@ -216,15 +216,15 @@ module.exports = HttpController =
 				res.send project_ids
 
 	flushQueuedProjects: (req, res, next = (error) ->) ->
-		res.setTimeout(5 * 60 * 1000)
 		options = 
 			limit : req.query.limit || 1000
 			timeout: 5 * 60 * 1000
 			dryRun : req.query.dryRun || false
 			min_delete_age: req.query.min_delete_age || 5 * 60 * 1000
-		DeleteQueueManager.flushAndDeleteOldProjects options, (err, project_ids)->
+		res.send 204
+		# run the flush in the background
+		DeleteQueueManager.flushAndDeleteOldProjects options, (err, flushed)->
 			if err?
 				logger.err err:err, "error flushing old projects"
-				res.send 500
-			else
-				res.send project_ids
+			else 
+				logger.log {flushed: flushed}, "flush of queued projects completed"

--- a/app/coffee/ProjectManager.coffee
+++ b/app/coffee/ProjectManager.coffee
@@ -83,7 +83,7 @@ module.exports = ProjectManager =
 	getProjectDocsTimestamps: (project_id, callback = (error) ->) ->
 		RedisManager.getDocIdsInProject project_id, (error, doc_ids) ->
 			return callback(error) if error?
-			return callback() if !doc_ids?.length
+			return callback(null, []) if !doc_ids?.length
 			RedisManager.getDocTimestamps doc_ids, (error, timestamps) ->
 				return callback(error) if error?
 				callback(null, timestamps)

--- a/app/coffee/ProjectManager.coffee
+++ b/app/coffee/ProjectManager.coffee
@@ -72,6 +72,22 @@ module.exports = ProjectManager =
 					else
 						callback(null)
 
+	queueFlushAndDeleteProject: (project_id, callback = (error) ->) ->
+		RedisManager.queueFlushAndDeleteProject project_id, (error) ->
+			if error?
+				logger.error {project_id: project_id, error:error}, "error adding project to flush and delete queue"
+				return callback(error)
+			Metrics.inc "queued-delete"
+			callback()
+
+	getProjectDocsTimestamps: (project_id, callback = (error) ->) ->
+		RedisManager.getDocIdsInProject project_id, (error, doc_ids) ->
+			return callback(error) if error?
+			return callback() if !doc_ids?.length
+			RedisManager.getDocTimestamps doc_ids, (error, timestamps) ->
+				return callback(error) if error?
+				callback(null, timestamps)
+
 	getProjectDocsAndFlushIfOld: (project_id, projectStateHash, excludeVersions = {}, _callback = (error, docs) ->) ->
 		timer = new Metrics.Timer("projectManager.getProjectDocsAndFlushIfOld")
 		callback = (args...) ->

--- a/app/coffee/RedisManager.coffee
+++ b/app/coffee/RedisManager.coffee
@@ -305,6 +305,7 @@ module.exports = RedisManager =
 			return callback() if !reply?.length # return if no projects ready to be processed
 			# pop the oldest entry (get and remove in a multi)
 			multi = rclient.multi()
+			# Poor man's version of ZPOPMIN, which is only available in Redis 5.
 			multi.zrange keys.flushAndDeleteQueue(), 0, 0, "WITHSCORES"
 			multi.zremrangebyrank keys.flushAndDeleteQueue(), 0, 0
 			multi.zcard keys.flushAndDeleteQueue() # the total length of the queue (for metrics)

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -80,6 +80,7 @@ module.exports =
 				lastUpdatedBy: ({doc_id}) -> "lastUpdatedBy:{#{doc_id}}"
 				lastUpdatedAt: ({doc_id}) -> "lastUpdatedAt:{#{doc_id}}"
 				pendingUpdates: ({doc_id}) -> "PendingUpdates:{#{doc_id}}"
+				flushAndDeleteQueue: () -> "DocUpdaterFlushAndDeleteQueue"
 			redisOptions:
 				keepAlive: 100
 	

--- a/test/acceptance/coffee/DeletingAProjectTests.coffee
+++ b/test/acceptance/coffee/DeletingAProjectTests.coffee
@@ -148,7 +148,7 @@ describe "Deleting a project", ->
 						# after deleting the project and putting it in the queue, flush the queue
 						setTimeout () ->
 							DocUpdaterClient.flushOldProjects (error, res, body) =>
-								done()
+							setTimeout done, 1000 # allow time for the flush to complete
 						, 100
 				, 200
 

--- a/test/acceptance/coffee/DeletingAProjectTests.coffee
+++ b/test/acceptance/coffee/DeletingAProjectTests.coffee
@@ -97,7 +97,7 @@ describe "Deleting a project", ->
 		it "should flush each doc in project history", ->
 			MockProjectHistoryApi.flushProject.calledWith(@project_id).should.equal true
 
-	describe "with the shutdown=true parameter from realtime", ->
+	describe "with the background=true parameter from realtime", ->
 		before (done) ->
 			sinon.spy MockWebApi, "setDocument"
 			sinon.spy MockTrackChangesApi, "flushDoc"
@@ -111,7 +111,11 @@ describe "Deleting a project", ->
 				setTimeout () =>
 					DocUpdaterClient.deleteProjectOnShutdown @project_id, (error, res, body) =>
 						@statusCode = res.statusCode
-						done()
+						# after deleting the project and putting it in the queue, flush the queue
+						setTimeout () ->
+							DocUpdaterClient.flushOldProjects (error, res, body) =>
+								done()
+						, 100
 				, 200
 
 		after ->

--- a/test/acceptance/coffee/helpers/DocUpdaterClient.coffee
+++ b/test/acceptance/coffee/helpers/DocUpdaterClient.coffee
@@ -78,6 +78,9 @@ module.exports = DocUpdaterClient =
 	deleteProjectOnShutdown: (project_id, callback = () ->) ->
 		request.del "http://localhost:3003/project/#{project_id}?background=true&shutdown=true", callback
 
+	flushOldProjects: (callback = () ->) ->
+		request.get "http://localhost:3003/flush_queued_projects?min_delete_age=1", callback
+
 	acceptChange: (project_id, doc_id, change_id, callback = () ->) ->
 		request.post "http://localhost:3003/project/#{project_id}/doc/#{doc_id}/change/#{change_id}/accept", callback
 

--- a/test/unit/coffee/HttpController/HttpControllerTests.coffee
+++ b/test/unit/coffee/HttpController/HttpControllerTests.coffee
@@ -14,6 +14,7 @@ describe "HttpController", ->
 			"./ProjectManager": @ProjectManager = {}
 			"logger-sharelatex" : @logger = { log: sinon.stub() }
 			"./ProjectFlusher": {flushAllProjects:->}
+			"./DeleteQueueManager": @DeleteQueueManager = {}
 			"./Metrics": @Metrics = {}
 			"./Errors" : Errors
 		@Metrics.Timer = class Timer
@@ -343,15 +344,15 @@ describe "HttpController", ->
 			it "should time the request", ->
 				@Metrics.Timer::done.called.should.equal true
 
-		describe "with the shutdown=true option from realtime", ->
+		describe "with the background=true option from realtime", ->
 			beforeEach ->
-				@ProjectManager.flushAndDeleteProjectWithLocks = sinon.stub().callsArgWith(2)
+				@ProjectManager.queueFlushAndDeleteProject = sinon.stub().callsArgWith(1)
 				@req.query = {background:true, shutdown:true}
 				@HttpController.deleteProject(@req, @res, @next)
 
-			it "should pass the skip_history_flush option when flushing the project", ->
-				@ProjectManager.flushAndDeleteProjectWithLocks
-					.calledWith(@project_id, {background:true, skip_history_flush:true})
+			it "should queue the flush and delete", ->
+				@ProjectManager.queueFlushAndDeleteProject
+					.calledWith(@project_id)
 					.should.equal true
 
 		describe "when an errors occurs", ->


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

This creates a queue  in redis which stores project flush and delete requests (`DELETE /project/:project_id`) for deferred processing.

There is a corresponding endpoint `GET /flush_queued_projects` which processes deletes which are older than 5 minutes and should be called from a `cron` job.  If any of the docs in the project have been edited since the original request then the flush and delete is skipped. 

The aim is to reduce the impact of real-time disconnections, which trigger an immediate flush of the project, followed by the docs being reloaded into redis when the user reconnects.  Assuming the user reconnects and edits within five minutes then the project will not be flushed.

I have added an endpoint `DELETE /project` which accepts multiple project ids - so that in future a realtime process can queue flushes for all clients with a single HTTP request, instead of making thousands of individual HTTP request.

We could enhance this by looking at reconnections rather than edits (if the user reconnects but doesn't edit the project then we will flush it) but I think we should see how this performs in production, it is probably sufficient.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2263

### Review

The delete processing is done in `DeleteQueueManager`.

There is a new redis key `flushAndDeleteQueue: () -> "DocUpdaterFlushAndDeleteQueue"`.  This is a "global" key since it is holding the state of the queue, I don't think we have done this before.  Under normal circumstances the queue should be a relatively small object - it only stores a project id and timestamp for each entry.

#### Potential Impact

Medium, since it defers processing the same flushing code is called in the end.

#### Manual Testing Performed

- [x] Acceptance tests added for flush and non-flush cases
- [x] Tested in local dev env

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

New metrics
  
| Metric | Type | Description |
|----------|--------|-----------------|
| `queued-delete`  | counter | incremented for each project flush request |
| `queued-delete-skipped` | counter | incremented when project would be deleted but has been edited |  
| `queued-delete-completed` | counter | incremented when project is deleted from redis |
| `queued-flush-backlog` | gauge | length of the current queue of pending deletions |

#### Who Needs to Know?

cc @henryoswald 