### PR TITLE
fix getDocTimestamps for multiple docs

### DIFF
--- a/app/coffee/RedisManager.coffee
+++ b/app/coffee/RedisManager.coffee
@@ -4,6 +4,7 @@ logger = require('logger-sharelatex')
 metrics = require('./Metrics')
 Errors = require "./Errors"
 crypto = require "crypto"
+async = require "async"
 ProjectHistoryRedisManager = require "./ProjectHistoryRedisManager"
 
 # Sometimes Redis calls take an unexpectedly long time.  We have to be
@@ -289,10 +290,9 @@ module.exports = RedisManager =
 
 	getDocTimestamps: (doc_ids, callback = (error, result) ->) ->
 		# get lastupdatedat timestamps for an array of doc_ids
-		multi = rclient.multi()
-		for doc_id in doc_ids
-			multi.get keys.lastUpdatedAt(doc_id: doc_id)
-		multi.exec callback
+		async.mapSeries doc_ids, (doc_id, cb) ->
+			rclient.get keys.lastUpdatedAt(doc_id: doc_id), cb
+		, callback
 
 	queueFlushAndDeleteProject: (project_id, callback) ->
 		# store the project id in a sorted set ordered by time


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Bug fix for https://github.com/overleaf/document-updater/pull/89

Multi does not work for different doc ids (this did not show up during testing locally as we do not use redis cluster in development).

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/document-updater/pull/89

### Review

NA

#### Potential Impact

NA

#### Manual Testing Performed

- [X]  Unit and acceptance tests

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

NA