### PR TITLE
add continuous background flush

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -14,6 +14,7 @@ if Settings.sentry?.dsn?
 
 RedisManager = require('./app/js/RedisManager')
 DispatchManager = require('./app/js/DispatchManager')
+DeleteQueueManager = require('./app/js/DeleteQueueManager')
 Errors = require "./app/js/Errors"
 HttpController = require "./app/js/HttpController"
 mongojs = require "./app/js/mongojs"
@@ -146,3 +147,7 @@ module.exports = app
 
 for signal in ['SIGINT', 'SIGHUP', 'SIGQUIT', 'SIGUSR1', 'SIGUSR2', 'SIGTERM', 'SIGABRT']
 	process.on signal, shutdownCleanly(signal)
+
+if Settings.continuousBackgroundFlush
+	logger.info "Starting continuous background flush"
+	DeleteQueueManager.startBackgroundFlush()

--- a/app.coffee
+++ b/app.coffee
@@ -143,11 +143,12 @@ host = Settings.internal.documentupdater.host or "localhost"
 if !module.parent # Called directly
 	app.listen port, host, ->
 		logger.info "Document-updater starting up, listening on #{host}:#{port}"
+		if Settings.continuousBackgroundFlush
+			logger.info "Starting continuous background flush"
+			DeleteQueueManager.startBackgroundFlush()
+
 module.exports = app
 
 for signal in ['SIGINT', 'SIGHUP', 'SIGQUIT', 'SIGUSR1', 'SIGUSR2', 'SIGTERM', 'SIGABRT']
 	process.on signal, shutdownCleanly(signal)
 
-if Settings.continuousBackgroundFlush
-	logger.info "Starting continuous background flush"
-	DeleteQueueManager.startBackgroundFlush()

--- a/app/coffee/DeleteQueueManager.coffee
+++ b/app/coffee/DeleteQueueManager.coffee
@@ -1,3 +1,4 @@
+Settings = require('settings-sharelatex')
 RedisManager = require "./RedisManager"
 ProjectManager = require "./ProjectManager"
 logger = require "logger-sharelatex"
@@ -61,3 +62,12 @@ module.exports = DeleteQueueManager =
                     flushNextProject()
 
         flushNextProject()
+
+    startBackgroundFlush: () ->
+        doFlush = () ->
+            if Settings.shuttingDown
+                logger.warn "discontinuing background flush due to shutdown"
+                return
+            DeleteQueueManager.flushAndDeleteOldProjects {timeout:1000,min_delete_age:3*60*1000,limit:1000}, () ->
+                setTimeout doFlush, 10
+        doFlush()

--- a/app/coffee/DeleteQueueManager.coffee
+++ b/app/coffee/DeleteQueueManager.coffee
@@ -23,7 +23,7 @@ async = require "async"
 module.exports = DeleteQueueManager =
     flushAndDeleteOldProjects: (options, callback) ->
         startTime = Date.now()
-        cutoffTime = startTime - options.min_delete_age 
+        cutoffTime = startTime - options.min_delete_age + 100 * (Math.random() - 0.5)
         count = 0
 
         flushProjectIfNotModified = (project_id, flushTimestamp, cb) ->

--- a/app/coffee/DeleteQueueManager.coffee
+++ b/app/coffee/DeleteQueueManager.coffee
@@ -70,6 +70,10 @@ module.exports = DeleteQueueManager =
             if Settings.shuttingDown
                 logger.warn "discontinuing background flush due to shutdown"
                 return
-            DeleteQueueManager.flushAndDeleteOldProjects {timeout:1000,min_delete_age:3*60*1000,limit:1000}, (err, flushed) ->
+            DeleteQueueManager.flushAndDeleteOldProjects {
+                timeout:1000,
+                min_delete_age:3*60*1000,
+                limit:1000 # high value, to ensure we always flush enough projects
+            }, (err, flushed) ->
                 setTimeout doFlush, (if flushed > 10 then SHORT_DELAY else LONG_DELAY)
         doFlush()

--- a/app/coffee/DeleteQueueManager.coffee
+++ b/app/coffee/DeleteQueueManager.coffee
@@ -64,10 +64,12 @@ module.exports = DeleteQueueManager =
         flushNextProject()
 
     startBackgroundFlush: () ->
+        SHORT_DELAY = 10
+        LONG_DELAY = 1000
         doFlush = () ->
             if Settings.shuttingDown
                 logger.warn "discontinuing background flush due to shutdown"
                 return
-            DeleteQueueManager.flushAndDeleteOldProjects {timeout:1000,min_delete_age:3*60*1000,limit:1000}, () ->
-                setTimeout doFlush, 10
+            DeleteQueueManager.flushAndDeleteOldProjects {timeout:1000,min_delete_age:3*60*1000,limit:1000}, (err, flushed) ->
+                setTimeout doFlush, (if flushed > 10 then SHORT_DELAY else LONG_DELAY)
         doFlush()

--- a/app/coffee/RedisManager.coffee
+++ b/app/coffee/RedisManager.coffee
@@ -295,8 +295,9 @@ module.exports = RedisManager =
 		multi.exec callback
 
 	queueFlushAndDeleteProject: (project_id, callback) ->
-		# store the project id in a sorted set ordered by time
-		rclient.zadd keys.flushAndDeleteQueue(), Date.now(), project_id, callback
+		# store the project id in a sorted set ordered by time with a random offset to smooth out spikes
+		SMOOTHING_OFFSET = if Settings.smoothingOffset > 0 then Math.round(Settings.smoothingOffset * Math.random()) else 0
+		rclient.zadd keys.flushAndDeleteQueue(), Date.now() + SMOOTHING_OFFSET, project_id, callback
 
 	getNextProjectToFlushAndDelete: (cutoffTime, callback = (error, key, timestamp)->) ->
 		# find the oldest queued flush that is before the cutoff time

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -97,3 +97,5 @@ module.exports =
 	publishOnIndividualChannels: process.env['PUBLISH_ON_INDIVIDUAL_CHANNELS'] or false
 
 	continuousBackgroundFlush: process.env['CONTINUOUS_BACKGROUND_FLUSH'] or false
+
+	smoothingOffset: process.env['SMOOTHING_OFFSET'] or 1000 # milliseconds

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -95,3 +95,5 @@ module.exports =
 		dsn: process.env.SENTRY_DSN
 
 	publishOnIndividualChannels: process.env['PUBLISH_ON_INDIVIDUAL_CHANNELS'] or false
+
+	continuousBackgroundFlush: process.env['CONTINUOUS_BACKGROUND_FLUSH'] or false

--- a/test/acceptance/coffee/DeletingAProjectTests.coffee
+++ b/test/acceptance/coffee/DeletingAProjectTests.coffee
@@ -147,9 +147,8 @@ describe "Deleting a project", ->
 						@statusCode = res.statusCode
 						# after deleting the project and putting it in the queue, flush the queue
 						setTimeout () ->
-							DocUpdaterClient.flushOldProjects (error, res, body) =>
-							setTimeout done, 1000 # allow time for the flush to complete
-						, 100
+							DocUpdaterClient.flushOldProjects done
+						, 2000
 				, 200
 
 		after ->


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

This adds a continuous background flush, to spread the load across all the docupdater processes.

The rate of flushes is too much for a single cron job to keep up with.  Also, putting all the work for the flushing onto one process is not good for autoscaling.  

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/document-updater/pull/89
https://github.com/overleaf/document-updater/pull/91

### Review

Small change. I have reduced the deferred flush time window from 5 minutes to 3 minutes, to reduce redis memory usage.

#### Potential Impact

Low, load tested by running flush endpoint continuously.

#### Manual Testing Performed

- [X]  Tested in local dev env.

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [x] Update the deployment config for docupdater to set `CONTINUOUS_BACKGROUND_FLUSH` to "true"

#### Metrics and Monitoring

Docupdater stackdriver dashboard

#### Who Needs to Know?

cc @henryoswald 