### PR TITLE
avoid project history queues building up with deferred flush

### DIFF
--- a/app/coffee/DeleteQueueManager.coffee
+++ b/app/coffee/DeleteQueueManager.coffee
@@ -38,7 +38,7 @@ module.exports = DeleteQueueManager =
                     logger.debug {project_id, timestamps, flushTimestamp}, "found newer timestamp, will skip delete"
                     return cb()
                 logger.log {project_id, flushTimestamp}, "flushing queued project"
-                ProjectManager.flushAndDeleteProjectWithLocks project_id, {skip_history_flush: true}, (err) ->
+                ProjectManager.flushAndDeleteProjectWithLocks project_id, {skip_history_flush: false}, (err) ->
                     if err?
                         logger.err {project_id, err}, "error flushing queued project"
                     metrics.inc "queued-delete-completed"

--- a/test/acceptance/coffee/DeletingAProjectTests.coffee
+++ b/test/acceptance/coffee/DeletingAProjectTests.coffee
@@ -169,6 +169,6 @@ describe "Deleting a project", ->
 			for doc in @docs
 				MockTrackChangesApi.flushDoc.calledWith(doc.id).should.equal true
 
-		it "should not flush to project history", ->
-			MockProjectHistoryApi.flushProject.called.should.equal false
+		it "should flush to project history", ->
+			MockProjectHistoryApi.flushProject.called.should.equal true
 


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Project history queues need to be flushed on deferred docupdater flush, otherwise redis memory usage increases too much.  We added 8.5GB and 100,000 queues to redis in the ~12 hours since it was deployed.

https://github.com/overleaf/document-updater/pull/89#discussion_r328565723
https://github.com/overleaf/document-updater/pull/89#discussion_r328638107

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/document-updater/pull/89

### Review

Minimal change.

#### Potential Impact

Low

#### Manual Testing Performed

- [ ] Unit and acceptance tests

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

- [ ] Check metrics for /status/queue in project history (only yodated oncer per hour)

#### Who Needs to Know?

@jdleesmiller @henryoswald 