### PR TITLE
add ioredis maxRetriesPerRequest

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -25,13 +25,13 @@ module.exports =
 			host: process.env['PUBSUB_REDIS_HOST'] or process.env['REDIS_HOST'] or "localhost"
 			port: process.env['PUBSUB_REDIS_PORT'] or process.env['REDIS_PORT'] or "6379"
 			password: process.env["PUBSUB_REDIS_PASSWORD"] or process.env["REDIS_PASSWORD"] or ""
-			maxRetriesPerRequest: 0
+			maxRetriesPerRequest: parseInt(process.env['REDIS_MAX_RETRIES_PER_REQUEST'] or "20")
 
 		history:
 			port: process.env["HISTORY_REDIS_PORT"] or process.env["REDIS_PORT"] or "6379"
 			host: process.env["HISTORY_REDIS_HOST"] or process.env["REDIS_HOST"] or "localhost"
 			password: process.env["HISTORY_REDIS_PASSWORD"] or process.env["REDIS_PASSWORD"] or ""
-			maxRetriesPerRequest: 0
+			maxRetriesPerRequest: parseInt(process.env['REDIS_MAX_RETRIES_PER_REQUEST'] or "20")
 			key_schema:
 				uncompressedHistoryOps: ({doc_id}) -> "UncompressedHistoryOps:{#{doc_id}}"
 				docsWithHistoryOps: ({project_id}) -> "DocsWithHistoryOps:{#{project_id}}"
@@ -40,7 +40,7 @@ module.exports =
 			port: process.env["HISTORY_REDIS_PORT"] or process.env["REDIS_PORT"] or "6379"
 			host: process.env["HISTORY_REDIS_HOST"] or process.env["REDIS_HOST"] or "localhost"
 			password: process.env["HISTORY_REDIS_PASSWORD"] or process.env["REDIS_PASSWORD"] or ""
-			maxRetriesPerRequest: 0
+			maxRetriesPerRequest: parseInt(process.env['REDIS_MAX_RETRIES_PER_REQUEST'] or "20")
 			key_schema:
 				projectHistoryOps: ({project_id}) -> "ProjectHistory:Ops:{#{project_id}}"
 				projectHistoryFirstOpTimestamp: ({project_id}) -> "ProjectHistory:FirstOpTimestamp:{#{project_id}}"
@@ -49,7 +49,7 @@ module.exports =
 			port: process.env["LOCK_REDIS_PORT"] or process.env["REDIS_PORT"] or "6379"
 			host: process.env["LOCK_REDIS_HOST"] or process.env["REDIS_HOST"] or "localhost"
 			password: process.env["LOCK_REDIS_PASSWORD"] or process.env["REDIS_PASSWORD"] or ""
-			maxRetriesPerRequest: 0
+			maxRetriesPerRequest: parseInt(process.env['REDIS_MAX_RETRIES_PER_REQUEST'] or "20")
 			key_schema:
 				blockingKey: ({doc_id}) -> "Blocking:{#{doc_id}}"
 
@@ -57,7 +57,7 @@ module.exports =
 			port: process.env["DOC_UPDATER_REDIS_PORT"] or process.env["REDIS_PORT"] or "6379"
 			host: process.env["DOC_UPDATER_REDIS_HOST"] or process.env["REDIS_HOST"] or "localhost"
 			password: process.env["DOC_UPDATER_REDIS_PASSWORD"] or process.env["REDIS_PASSWORD"] or ""
-			maxRetriesPerRequest: 0
+			maxRetriesPerRequest: parseInt(process.env['REDIS_MAX_RETRIES_PER_REQUEST'] or "20")
 			key_schema:
 				blockingKey: ({doc_id}) -> "Blocking:{#{doc_id}}"
 				docLines: ({doc_id}) -> "doclines:{#{doc_id}}"

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -25,11 +25,13 @@ module.exports =
 			host: process.env['PUBSUB_REDIS_HOST'] or process.env['REDIS_HOST'] or "localhost"
 			port: process.env['PUBSUB_REDIS_PORT'] or process.env['REDIS_PORT'] or "6379"
 			password: process.env["PUBSUB_REDIS_PASSWORD"] or process.env["REDIS_PASSWORD"] or ""
-				
+			maxRetriesPerRequest: 0
+
 		history:
 			port: process.env["HISTORY_REDIS_PORT"] or process.env["REDIS_PORT"] or "6379"
 			host: process.env["HISTORY_REDIS_HOST"] or process.env["REDIS_HOST"] or "localhost"
 			password: process.env["HISTORY_REDIS_PASSWORD"] or process.env["REDIS_PASSWORD"] or ""
+			maxRetriesPerRequest: 0
 			key_schema:
 				uncompressedHistoryOps: ({doc_id}) -> "UncompressedHistoryOps:{#{doc_id}}"
 				docsWithHistoryOps: ({project_id}) -> "DocsWithHistoryOps:{#{project_id}}"
@@ -38,6 +40,7 @@ module.exports =
 			port: process.env["HISTORY_REDIS_PORT"] or process.env["REDIS_PORT"] or "6379"
 			host: process.env["HISTORY_REDIS_HOST"] or process.env["REDIS_HOST"] or "localhost"
 			password: process.env["HISTORY_REDIS_PASSWORD"] or process.env["REDIS_PASSWORD"] or ""
+			maxRetriesPerRequest: 0
 			key_schema:
 				projectHistoryOps: ({project_id}) -> "ProjectHistory:Ops:{#{project_id}}"
 				projectHistoryFirstOpTimestamp: ({project_id}) -> "ProjectHistory:FirstOpTimestamp:{#{project_id}}"
@@ -46,6 +49,7 @@ module.exports =
 			port: process.env["LOCK_REDIS_PORT"] or process.env["REDIS_PORT"] or "6379"
 			host: process.env["LOCK_REDIS_HOST"] or process.env["REDIS_HOST"] or "localhost"
 			password: process.env["LOCK_REDIS_PASSWORD"] or process.env["REDIS_PASSWORD"] or ""
+			maxRetriesPerRequest: 0
 			key_schema:
 				blockingKey: ({doc_id}) -> "Blocking:{#{doc_id}}"
 
@@ -53,6 +57,7 @@ module.exports =
 			port: process.env["DOC_UPDATER_REDIS_PORT"] or process.env["REDIS_PORT"] or "6379"
 			host: process.env["DOC_UPDATER_REDIS_HOST"] or process.env["REDIS_HOST"] or "localhost"
 			password: process.env["DOC_UPDATER_REDIS_PASSWORD"] or process.env["REDIS_PASSWORD"] or ""
+			maxRetriesPerRequest: 0
 			key_schema:
 				blockingKey: ({doc_id}) -> "Blocking:{#{doc_id}}"
 				docLines: ({doc_id}) -> "doclines:{#{doc_id}}"

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -25,8 +25,6 @@ module.exports =
 			host: process.env['PUBSUB_REDIS_HOST'] or process.env['REDIS_HOST'] or "localhost"
 			port: process.env['PUBSUB_REDIS_PORT'] or process.env['REDIS_PORT'] or "6379"
 			password: process.env["PUBSUB_REDIS_PASSWORD"] or process.env["REDIS_PASSWORD"] or ""
-			redisOptions:	
-				keepAlive: 100
 				
 		history:
 			port: process.env["HISTORY_REDIS_PORT"] or process.env["REDIS_PORT"] or "6379"
@@ -35,8 +33,6 @@ module.exports =
 			key_schema:
 				uncompressedHistoryOps: ({doc_id}) -> "UncompressedHistoryOps:{#{doc_id}}"
 				docsWithHistoryOps: ({project_id}) -> "DocsWithHistoryOps:{#{project_id}}"
-			redisOptions:
-				keepAlive: 100
 
 		project_history:
 			port: process.env["HISTORY_REDIS_PORT"] or process.env["REDIS_PORT"] or "6379"
@@ -45,8 +41,6 @@ module.exports =
 			key_schema:
 				projectHistoryOps: ({project_id}) -> "ProjectHistory:Ops:{#{project_id}}"
 				projectHistoryFirstOpTimestamp: ({project_id}) -> "ProjectHistory:FirstOpTimestamp:{#{project_id}}"
-			redisOptions:
-				keepAlive: 100
 
 		lock:
 			port: process.env["LOCK_REDIS_PORT"] or process.env["REDIS_PORT"] or "6379"
@@ -54,15 +48,11 @@ module.exports =
 			password: process.env["LOCK_REDIS_PASSWORD"] or process.env["REDIS_PASSWORD"] or ""
 			key_schema:
 				blockingKey: ({doc_id}) -> "Blocking:{#{doc_id}}"
-			redisOptions:
-				keepAlive: 100
 
 		documentupdater:
 			port: process.env["DOC_UPDATER_REDIS_PORT"] or process.env["REDIS_PORT"] or "6379"
 			host: process.env["DOC_UPDATER_REDIS_HOST"] or process.env["REDIS_HOST"] or "localhost"
 			password: process.env["DOC_UPDATER_REDIS_PASSWORD"] or process.env["REDIS_PASSWORD"] or ""
-			redisOptions:
-				keepAlive: 100
 			key_schema:
 				blockingKey: ({doc_id}) -> "Blocking:{#{doc_id}}"
 				docLines: ({doc_id}) -> "doclines:{#{doc_id}}"
@@ -81,8 +71,6 @@ module.exports =
 				lastUpdatedAt: ({doc_id}) -> "lastUpdatedAt:{#{doc_id}}"
 				pendingUpdates: ({doc_id}) -> "PendingUpdates:{#{doc_id}}"
 				flushAndDeleteQueue: () -> "DocUpdaterFlushAndDeleteQueue"
-			redisOptions:
-				keepAlive: 100
 	
 	max_doc_length: 2 * 1024 * 1024 # 2mb
 


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Try out the ioredis maxRetriesPerRequest = 0 option, to see if improves behaviour where docupdater gets into a bad state.

Having thought about this over the weekend, it is not safe to deploy this to all docupdaters because we can't predict how it will behave in production if there is an error. 

@mans0954 I talked to Henry about setting up some kind of canary deploy in a simple way where we can just have one docupdater running with this option.  Could you help with that?  Thanks.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/luin/ioredis/issues/965

### Review

Small change.  I have removed the old keepAlive options which have no effect under `redisOptions:` which only applies to `cluster` configurations.  If we want to add these back we should just use the `keepAlive` option at the top level, with `maxRetriesPerRequest`

#### Potential Impact

High - don't deploy.

#### Manual Testing Performed

I tried this locally restarting redis or pausing it  while everything was running but I couldn't trigger anything that looked like `maxRetriesPerRequest` was having an effect.

#### Accessibility

NA

### Deployment

Don't deploy -  PR for future use only.

#### Deployment Checklist

- [ ] Set up a canary deploy

#### Metrics and Monitoring

Docupdater metrics/logs in stackdriver.

#### Who Needs to Know?

cc @gh2k @henryoswald @jdleesmiller 