### PR TITLE
filter track-changes updates for projects using project-history

### DIFF
--- a/app/coffee/DocumentManager.coffee
+++ b/app/coffee/DocumentManager.coffee
@@ -23,12 +23,14 @@ module.exports = DocumentManager =
 			return callback(error) if error?
 			if !lines? or !version?
 				logger.log {project_id, doc_id}, "doc not in redis so getting from persistence API"
-				PersistenceManager.getDoc project_id, doc_id, (error, lines, version, ranges, pathname, projectHistoryId) ->
+				PersistenceManager.getDoc project_id, doc_id, (error, lines, version, ranges, pathname, projectHistoryId, projectHistoryType) ->
 					return callback(error) if error?
-					logger.log {project_id, doc_id, lines, version, pathname, projectHistoryId}, "got doc from persistence API"
+					logger.log {project_id, doc_id, lines, version, pathname, projectHistoryId, projectHistoryType}, "got doc from persistence API"
 					RedisManager.putDocInMemory project_id, doc_id, lines, version, ranges, pathname, projectHistoryId, (error) ->
 						return callback(error) if error?
-						callback null, lines, version, ranges, pathname, projectHistoryId, null, false
+						RedisManager.setHistoryType doc_id, projectHistoryType, (error) ->
+							return callback(error) if error?
+							callback null, lines, version, ranges, pathname, projectHistoryId, null, false
 			else
 				callback null, lines, version, ranges, pathname, projectHistoryId, unflushedTime, true
 

--- a/app/coffee/HistoryManager.coffee
+++ b/app/coffee/HistoryManager.coffee
@@ -11,14 +11,19 @@ module.exports = HistoryManager =
 		if !Settings.apis?.trackchanges?
 			logger.warn { doc_id }, "track changes API is not configured, so not flushing"
 			return
-
-		url = "#{Settings.apis.trackchanges.url}/project/#{project_id}/doc/#{doc_id}/flush"
-		logger.log { project_id, doc_id, url }, "flushing doc in track changes api"
-		request.post url, (error, res, body)->
-			if error?
-				logger.error { error, doc_id, project_id}, "track changes doc to track changes api"
-			else if res.statusCode < 200 and res.statusCode >= 300
-				logger.error { doc_id, project_id }, "track changes api returned a failure status code: #{res.statusCode}"
+		RedisManager.getHistoryType doc_id, (err, projectHistoryType) ->
+			if err?
+				logger.error {err, doc_id}, "error getting history type"
+			else if projectHistoryType is "project-history"
+				logger.debug {doc_id, projectHistoryType}, "skipping track-changes flush"
+			else
+				url = "#{Settings.apis.trackchanges.url}/project/#{project_id}/doc/#{doc_id}/flush"
+				logger.log { project_id, doc_id, url, projectHistoryType }, "flushing doc in track changes api"
+				request.post url, (error, res, body)->
+					if error?
+						logger.error { error, doc_id, project_id}, "track changes doc to track changes api"
+					else if res.statusCode < 200 and res.statusCode >= 300
+						logger.error { doc_id, project_id }, "track changes api returned a failure status code: #{res.statusCode}"
 
 	# flush changes in the background
 	flushProjectChangesAsync: (project_id) ->
@@ -52,6 +57,7 @@ module.exports = HistoryManager =
 		if ops.length == 0
 			return callback()
 
+		# record updates for project history
 		if Settings.apis?.project_history?.enabled
 			if HistoryManager.shouldFlushHistoryOps(project_ops_length, ops.length, HistoryManager.FLUSH_PROJECT_EVERY_N_OPS)
 				# Do this in the background since it uses HTTP and so may be too
@@ -59,6 +65,13 @@ module.exports = HistoryManager =
 				logger.log { project_ops_length, project_id }, "flushing project history api"
 				HistoryManager.flushProjectChangesAsync project_id
 
+		# if the doc_ops_length is undefined it means the project is not using track-changes
+		# so we can bail out here
+		if typeof(doc_ops_length) is 'undefined'
+			logger.debug { project_id, doc_id}, "skipping flush to track-changes, only using project-history"
+			return callback()
+
+		# record updates for track-changes
 		HistoryRedisManager.recordDocHasHistoryOps project_id, doc_id, ops, (error) ->
 			return callback(error) if error?
 			if HistoryManager.shouldFlushHistoryOps(doc_ops_length, ops.length, HistoryManager.FLUSH_DOC_EVERY_N_OPS)

--- a/app/coffee/HistoryManager.coffee
+++ b/app/coffee/HistoryManager.coffee
@@ -13,8 +13,9 @@ module.exports = HistoryManager =
 			return
 		RedisManager.getHistoryType doc_id, (err, projectHistoryType) ->
 			if err?
-				logger.error {err, doc_id}, "error getting history type"
-			else if projectHistoryType is "project-history"
+				logger.warn {err, doc_id}, "error getting history type"
+				# if there's an error continue and flush to track-changes for safety
+			if projectHistoryType is "project-history"
 				logger.debug {doc_id, projectHistoryType}, "skipping track-changes flush"
 			else
 				url = "#{Settings.apis.trackchanges.url}/project/#{project_id}/doc/#{doc_id}/flush"

--- a/app/coffee/PersistenceManager.coffee
+++ b/app/coffee/PersistenceManager.coffee
@@ -13,7 +13,7 @@ request = (require("requestretry")).defaults({
 MAX_HTTP_REQUEST_LENGTH = 5000 # 5 seconds
 
 module.exports = PersistenceManager =
-	getDoc: (project_id, doc_id, _callback = (error, lines, version, ranges, pathname, projectHistoryId) ->) ->
+	getDoc: (project_id, doc_id, _callback = (error, lines, version, ranges, pathname, projectHistoryId, projectHistoryType) ->) ->
 		timer = new Metrics.Timer("persistenceManager.getDoc")
 		callback = (args...) ->
 			timer.done()
@@ -44,7 +44,7 @@ module.exports = PersistenceManager =
 					return callback(new Error("web API response had no valid doc version"))
 				if !body.pathname?
 					return callback(new Error("web API response had no valid doc pathname"))
-				return callback null, body.lines, body.version, body.ranges, body.pathname, body.projectHistoryId
+				return callback null, body.lines, body.version, body.ranges, body.pathname, body.projectHistoryId, body.projectHistoryType
 			else if res.statusCode == 404
 				return callback(new Errors.NotFoundError("doc not not found: #{url}"))
 			else

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -70,13 +70,14 @@ module.exports =
 				unflushedTime: ({doc_id}) -> "UnflushedTime:{#{doc_id}}"
 				pathname: ({doc_id}) -> "Pathname:{#{doc_id}}"
 				projectHistoryId: ({doc_id}) -> "ProjectHistoryId:{#{doc_id}}"
+				projectHistoryType: ({doc_id}) -> "ProjectHistoryType:{#{doc_id}}"
 				projectState: ({project_id}) -> "ProjectState:{#{project_id}}"
 				pendingUpdates: ({doc_id}) -> "PendingUpdates:{#{doc_id}}"
 				lastUpdatedBy: ({doc_id}) -> "lastUpdatedBy:{#{doc_id}}"
 				lastUpdatedAt: ({doc_id}) -> "lastUpdatedAt:{#{doc_id}}"
 				pendingUpdates: ({doc_id}) -> "PendingUpdates:{#{doc_id}}"
 				flushAndDeleteQueue: () -> "DocUpdaterFlushAndDeleteQueue"
-	
+
 	max_doc_length: 2 * 1024 * 1024 # 2mb
 
 	dispatcherCount: process.env["DISPATCHER_COUNT"]

--- a/test/unit/coffee/DocumentManager/DocumentManagerTests.coffee
+++ b/test/unit/coffee/DocumentManager/DocumentManagerTests.coffee
@@ -27,6 +27,7 @@ describe "DocumentManager", ->
 			"./RangesManager": @RangesManager = {}
 		@project_id = "project-id-123"
 		@projectHistoryId = "history-id-123"
+		@projectHistoryType = "project-history"
 		@doc_id = "doc-id-123"
 		@user_id = 1234
 		@callback = sinon.stub()
@@ -178,8 +179,9 @@ describe "DocumentManager", ->
 		describe "when the doc does not exist in Redis", ->
 			beforeEach ->
 				@RedisManager.getDoc = sinon.stub().callsArgWith(2, null, null, null, null, null, null)
-				@PersistenceManager.getDoc = sinon.stub().callsArgWith(2, null, @lines, @version, @ranges, @pathname, @projectHistoryId)
+				@PersistenceManager.getDoc = sinon.stub().callsArgWith(2, null, @lines, @version, @ranges, @pathname, @projectHistoryId, @projectHistoryType)
 				@RedisManager.putDocInMemory = sinon.stub().yields()
+				@RedisManager.setHistoryType = sinon.stub().yields()
 				@DocumentManager.getDoc @project_id, @doc_id, @callback
 
 			it "should try to get the doc from Redis", ->
@@ -195,6 +197,11 @@ describe "DocumentManager", ->
 			it "should set the doc in Redis", ->
 				@RedisManager.putDocInMemory
 					.calledWith(@project_id, @doc_id, @lines, @version, @ranges, @pathname, @projectHistoryId)
+					.should.equal true
+
+			it "should set the history type in Redis", ->
+				@RedisManager.setHistoryType
+					.calledWith(@doc_id, @projectHistoryType)
 					.should.equal true
 
 			it "should call the callback with the doc info", ->

--- a/test/unit/coffee/RedisManager/RedisManagerTests.coffee
+++ b/test/unit/coffee/RedisManager/RedisManagerTests.coffee
@@ -34,6 +34,7 @@ describe "RedisManager", ->
 								ranges: ({doc_id}) -> "Ranges:#{doc_id}"
 								pathname: ({doc_id}) -> "Pathname:#{doc_id}"
 								projectHistoryId: ({doc_id}) -> "ProjectHistoryId:#{doc_id}"
+								projectHistoryType: ({doc_id}) -> "ProjectHistoryType:#{doc_id}"
 								projectState: ({project_id}) -> "ProjectState:#{project_id}"
 								unflushedTime: ({doc_id}) -> "UnflushedTime:#{doc_id}"
 								lastUpdatedBy: ({doc_id}) -> "lastUpdatedBy:#{doc_id}"


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

This PR filters out track-changes updates for projects using project-history.  It uses the extra information about the project type returned by web in https://github.com/overleaf/web-internal/pull/2378 to make a decision about whether to (a) push ops onto the `uncompressedHistoryOps` queue used by track-changes and (b) make flush requests to `track-changes`.

#### Screenshots

NA

#### Related Issues / PRs


https://github.com/overleaf/web-internal/pull/2378
https://github.com/overleaf/issues/issues/2392

### Review

When we request the document from web we get a `projectHistoryType` property which can be either `project-history` or `undefined`.  If it is undefined the project is still using track-changes, otherwise we only need to send updates to project-history.

#### Potential Impact

Loss of history updates for track changes, there should not be too many projects exclusively relying on this any more.

#### Manual Testing Performed

- [X] Test in local dev env
- [X] Unit and acceptance tests 

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [x] Deploy https://github.com/overleaf/web-internal/pull/2378 before this, so that all web pods are sending the `projectHistoryType` information for consistency.

#### Metrics and Monitoring

Need to add metrics to the existing code, so we can see before and after.  I will do this in a separate PR.

#### Who Needs to Know?

@natestemen @emcsween 