### PR TITLE
add metrics for history flushes

### DIFF
--- a/app/coffee/HistoryManager.coffee
+++ b/app/coffee/HistoryManager.coffee
@@ -5,13 +5,14 @@ Settings = require "settings-sharelatex"
 HistoryRedisManager = require "./HistoryRedisManager"
 ProjectHistoryRedisManager = require "./ProjectHistoryRedisManager"
 RedisManager = require "./RedisManager"
+metrics = require "./Metrics"
 
 module.exports = HistoryManager =
 	flushDocChangesAsync: (project_id, doc_id) ->
 		if !Settings.apis?.trackchanges?
 			logger.warn { doc_id }, "track changes API is not configured, so not flushing"
 			return
-
+		metrics.inc 'history-flush', 1, { status: 'track-changes'}
 		url = "#{Settings.apis.trackchanges.url}/project/#{project_id}/doc/#{doc_id}/flush"
 		logger.log { project_id, doc_id, url }, "flushing doc in track changes api"
 		request.post url, (error, res, body)->
@@ -31,6 +32,7 @@ module.exports = HistoryManager =
 		if options.skip_history_flush
 			logger.log {project_id}, "skipping flush of project history"
 			return callback()
+		metrics.inc 'history-flush', 1, { status: 'project-history'}
 		url = "#{Settings.apis.project_history.url}/project/#{project_id}/flush"
 		qs = {}
 		qs.background = true if options.background # pass on the background flush option if present

--- a/test/unit/coffee/HistoryManager/HistoryManagerTests.coffee
+++ b/test/unit/coffee/HistoryManager/HistoryManagerTests.coffee
@@ -20,6 +20,7 @@ describe "HistoryManager", ->
 			"./HistoryRedisManager": @HistoryRedisManager = {}
 			"./RedisManager": @RedisManager = {}
 			"./ProjectHistoryRedisManager": @ProjectHistoryRedisManager = {}
+			"./Metrics": @metrics = {inc: sinon.stub()}
 		@project_id = "mock-project-id"
 		@doc_id = "mock-doc-id"
 		@callback = sinon.stub()


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Add metrics for history flushes (project-history vs track-changes) prior to deploying https://github.com/overleaf/document-updater/pull/101

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/document-updater/pull/101

### Review

Metrics only

#### Potential Impact

Low

#### Manual Testing Performed

- [X] Unit and acceptance tests 

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

Add to docupdater dashboard

#### Who Needs to Know?

@henryoswald 