### PR TITLE
filter track changes updates

### DIFF
--- a/app/coffee/HistoryManager.coffee
+++ b/app/coffee/HistoryManager.coffee
@@ -16,7 +16,7 @@ module.exports = HistoryManager =
 			if err?
 				logger.warn {err, doc_id}, "error getting history type"
 				# if there's an error continue and flush to track-changes for safety
-			if projectHistoryType is "project-history"
+			if Settings.disableDoubleFlush and projectHistoryType is "project-history"
 				logger.debug {doc_id, projectHistoryType}, "skipping track-changes flush"
 			else
 				metrics.inc 'history-flush', 1, { status: 'track-changes'}

--- a/app/coffee/RedisManager.coffee
+++ b/app/coffee/RedisManager.coffee
@@ -156,8 +156,9 @@ module.exports = RedisManager =
 				callback null, docLines, version, ranges, pathname, projectHistoryId, unflushedTime, lastUpdatedAt, lastUpdatedBy
 
 	getDocVersion: (doc_id, callback = (error, version, projectHistoryType) ->) ->
-		rclient.mget keys.docVersion(doc_id: doc_id), keys.projectHistoryType(doc_id:doc_id), (error, version, projectHistoryType) ->
+		rclient.mget keys.docVersion(doc_id: doc_id), keys.projectHistoryType(doc_id:doc_id), (error, result) ->
 			return callback(error) if error?
+			[version, projectHistoryType] = result || []
 			version = parseInt(version, 10)
 			callback null, version, projectHistoryType
 

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -93,3 +93,5 @@ module.exports =
 	continuousBackgroundFlush: process.env['CONTINUOUS_BACKGROUND_FLUSH'] or false
 
 	smoothingOffset: process.env['SMOOTHING_OFFSET'] or 1000 # milliseconds
+
+	disableDoubleFlush: process.env['DISABLE_DOUBLE_FLUSH'] or false # don't flush track-changes for projects using project-history

--- a/test/unit/coffee/HistoryManager/HistoryManagerTests.coffee
+++ b/test/unit/coffee/HistoryManager/HistoryManagerTests.coffee
@@ -39,8 +39,19 @@ describe "HistoryManager", ->
 					.calledWith("#{@Settings.apis.trackchanges.url}/project/#{@project_id}/doc/#{@doc_id}/flush")
 					.should.equal true
 
-		describe "when the project uses project history", ->
+		describe "when the project uses project history and double flush is not disabled", ->
 			beforeEach ->
+				@RedisManager.getHistoryType = sinon.stub().yields(null, 'project-history')
+				@HistoryManager.flushDocChangesAsync @project_id, @doc_id
+
+			it "should send a request to the track changes api", ->
+				@request.post
+					.called
+					.should.equal true
+
+		describe "when the project uses project history and double flush is disabled", ->
+			beforeEach ->
+				@Settings.disableDoubleFlush = true
 				@RedisManager.getHistoryType = sinon.stub().yields(null, 'project-history')
 				@HistoryManager.flushDocChangesAsync @project_id, @doc_id
 
@@ -48,6 +59,7 @@ describe "HistoryManager", ->
 				@request.post
 					.called
 					.should.equal false
+
 
 	describe "flushProjectChangesAsync", ->
 		beforeEach ->


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

The previous deployment in https://github.com/overleaf/document-updater/pull/101 had a bug which caused the updates to still be placed on the track-changes queue, but not flushed.

This fixes the bug, adds some tests, adds metrics for the two queue operations, and adds a setting to allow us to continue to flush to track changes even after we stop putting updates on the queue (this will clear out track-changes queues for active projects while we confirm the updates are no longer being queued).

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/document-updater/pull/101

### Review

The bug was that in `getDocVersion` the redis command `GET` was changed to `MGET`, which returns an array instead of multiple arguments. However, the method continued to work because the version is computed with parseInt(x) which surprisingly returns the expected value (the first entry in the array) if x is an array.   Only the second argument, `projectHistoryType`, was returned incorrectly as `undefined` on every call.

```
> x=[3,"hello"]
[ 3, 'hello' ]
> parseInt(x)
3
> x.toString()
'3,hello'
> parseInt("3,hello")
3
```


#### Potential Impact

Should now "fail safe" by continuing to flush to track changes even though we are not adding updates to the queue for it.


#### Manual Testing Performed

- [x] Unit and acceptance tests
- [x] Tests in local dev env

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [ ]  Check redis memory usage is not increasing after 1 hour.
- [ ] Later, redeploy with `DISABLE_DOUBLE_FLUSH=true`

#### Metrics and Monitoring

- Redis memory
- Document updater dashboard for flushes.

#### Who Needs to Know?

@emcsween @natestemen 