### PR TITLE
add failure/retry metrics for web-api requests

### DIFF
--- a/app/coffee/PersistenceManager.coffee
+++ b/app/coffee/PersistenceManager.coffee
@@ -21,11 +21,11 @@ updateMetric = (method, error, response) ->
 			error.code
 		else if response?
 			response.statusCode
-	Metrics.inc method, {status: status}
-	if error?.attempts > 0
-		Metrics.inc "#{method}-attempts", {status: 'error'}
-	if response?.attempts > 0
-		Metrics.inc "#{method}-attempts", {status: 'success'}
+	Metrics.inc method, 1, {status: status}
+	if error?.attempts > 1
+		Metrics.inc "#{method}-retries", 1, {status: 'error'}
+	if response?.attempts > 1
+		Metrics.inc "#{method}-retries", 1, {status: 'success'}
 
 module.exports = PersistenceManager =
 	getDoc: (project_id, doc_id, _callback = (error, lines, version, ranges, pathname, projectHistoryId, projectHistoryType) ->) ->

--- a/test/unit/coffee/PersistenceManager/PersistenceManagerTests.coffee
+++ b/test/unit/coffee/PersistenceManager/PersistenceManagerTests.coffee
@@ -73,7 +73,7 @@ describe "PersistenceManager", ->
 				@Metrics.Timer::done.called.should.equal true
 
 			it "should increment the metric", ->
-				@Metrics.inc.calledWith("getDoc", {status: 200}).should.equal true
+				@Metrics.inc.calledWith("getDoc", 1, {status: 200}).should.equal true
 
 		describe "when request returns an error", ->
 			beforeEach ->
@@ -89,7 +89,7 @@ describe "PersistenceManager", ->
 				@Metrics.Timer::done.called.should.equal true
 
 			it "should increment the metric", ->
-				@Metrics.inc.calledWith("getDoc", {status: "EOOPS"}).should.equal true
+				@Metrics.inc.calledWith("getDoc", 1, {status: "EOOPS"}).should.equal true
 
 		describe "when the request returns 404", ->
 			beforeEach ->
@@ -103,7 +103,7 @@ describe "PersistenceManager", ->
 				@Metrics.Timer::done.called.should.equal true
 
 			it "should increment the metric", ->
-				@Metrics.inc.calledWith("getDoc", {status: 404}).should.equal true
+				@Metrics.inc.calledWith("getDoc", 1, {status: 404}).should.equal true
 
 		describe "when the request returns an error status code", ->
 			beforeEach ->
@@ -117,7 +117,7 @@ describe "PersistenceManager", ->
 				@Metrics.Timer::done.called.should.equal true
 
 			it "should increment the metric", ->
-				@Metrics.inc.calledWith("getDoc", {status: 500}).should.equal true
+				@Metrics.inc.calledWith("getDoc", 1, {status: 500}).should.equal true
 
 		describe "when request returns an doc without lines", ->
 			beforeEach ->
@@ -179,7 +179,7 @@ describe "PersistenceManager", ->
 				@Metrics.Timer::done.called.should.equal true
 
 			it "should increment the metric", ->
-				@Metrics.inc.calledWith("setDoc", {status: 200}).should.equal true
+				@Metrics.inc.calledWith("setDoc", 1, {status: 200}).should.equal true
 
 		describe "when request returns an error", ->
 			beforeEach ->
@@ -195,7 +195,7 @@ describe "PersistenceManager", ->
 				@Metrics.Timer::done.called.should.equal true
 
 			it "should increment the metric", ->
-				@Metrics.inc.calledWith("setDoc", {status: "EOOPS"}).should.equal true
+				@Metrics.inc.calledWith("setDoc", 1, {status: "EOOPS"}).should.equal true
 
 		describe "when the request returns 404", ->
 			beforeEach ->
@@ -209,7 +209,7 @@ describe "PersistenceManager", ->
 				@Metrics.Timer::done.called.should.equal true
 
 			it "should increment the metric", ->
-				@Metrics.inc.calledWith("setDoc", {status: 404}).should.equal true
+				@Metrics.inc.calledWith("setDoc", 1, {status: 404}).should.equal true
 
 		describe "when the request returns an error status code", ->
 			beforeEach ->
@@ -223,4 +223,4 @@ describe "PersistenceManager", ->
 				@Metrics.Timer::done.called.should.equal true
 
 			it "should increment the metric", ->
-				@Metrics.inc.calledWith("setDoc", {status: 500}).should.equal true
+				@Metrics.inc.calledWith("setDoc", 1, {status: 500}).should.equal true

--- a/test/unit/coffee/PersistenceManager/PersistenceManagerTests.coffee
+++ b/test/unit/coffee/PersistenceManager/PersistenceManagerTests.coffee
@@ -15,6 +15,7 @@ describe "PersistenceManager", ->
 			"./Metrics": @Metrics =
 				Timer: class Timer
 					done: sinon.stub()
+				inc: sinon.stub()
 			"logger-sharelatex": @logger = {log: sinon.stub(), err: sinon.stub()}
 		@project_id = "project-id-123"
 		@projectHistoryId = "history-id-123"
@@ -71,9 +72,14 @@ describe "PersistenceManager", ->
 			it "should time the execution", ->
 				@Metrics.Timer::done.called.should.equal true
 
+			it "should increment the metric", ->
+				@Metrics.inc.calledWith("getDoc", {status: 200}).should.equal true
+
 		describe "when request returns an error", ->
 			beforeEach ->
-				@request.callsArgWith(1, @error = new Error("oops"), null, null)
+				@error = new Error("oops")
+				@error.code = "EOOPS"
+				@request.callsArgWith(1, @error, null, null)
 				@PersistenceManager.getDoc(@project_id, @doc_id, @callback)
 
 			it "should return the error", ->
@@ -81,6 +87,9 @@ describe "PersistenceManager", ->
 
 			it "should time the execution", ->
 				@Metrics.Timer::done.called.should.equal true
+
+			it "should increment the metric", ->
+				@Metrics.inc.calledWith("getDoc", {status: "EOOPS"}).should.equal true
 
 		describe "when the request returns 404", ->
 			beforeEach ->
@@ -93,6 +102,9 @@ describe "PersistenceManager", ->
 			it "should time the execution", ->
 				@Metrics.Timer::done.called.should.equal true
 
+			it "should increment the metric", ->
+				@Metrics.inc.calledWith("getDoc", {status: 404}).should.equal true
+
 		describe "when the request returns an error status code", ->
 			beforeEach ->
 				@request.callsArgWith(1, null, {statusCode: 500}, "")
@@ -103,6 +115,9 @@ describe "PersistenceManager", ->
 
 			it "should time the execution", ->
 				@Metrics.Timer::done.called.should.equal true
+
+			it "should increment the metric", ->
+				@Metrics.inc.calledWith("getDoc", {status: 500}).should.equal true
 
 		describe "when request returns an doc without lines", ->
 			beforeEach ->
@@ -163,9 +178,14 @@ describe "PersistenceManager", ->
 			it "should time the execution", ->
 				@Metrics.Timer::done.called.should.equal true
 
+			it "should increment the metric", ->
+				@Metrics.inc.calledWith("setDoc", {status: 200}).should.equal true
+
 		describe "when request returns an error", ->
 			beforeEach ->
-				@request.callsArgWith(1, @error = new Error("oops"), null, null)
+				@error = new Error("oops")
+				@error.code = "EOOPS"
+				@request.callsArgWith(1, @error, null, null)
 				@PersistenceManager.setDoc(@project_id, @doc_id, @lines, @version, @ranges, @lastUpdatedAt, @lastUpdatedBy, @callback)
 
 			it "should return the error", ->
@@ -173,6 +193,9 @@ describe "PersistenceManager", ->
 
 			it "should time the execution", ->
 				@Metrics.Timer::done.called.should.equal true
+
+			it "should increment the metric", ->
+				@Metrics.inc.calledWith("setDoc", {status: "EOOPS"}).should.equal true
 
 		describe "when the request returns 404", ->
 			beforeEach ->
@@ -185,6 +208,9 @@ describe "PersistenceManager", ->
 			it "should time the execution", ->
 				@Metrics.Timer::done.called.should.equal true
 
+			it "should increment the metric", ->
+				@Metrics.inc.calledWith("setDoc", {status: 404}).should.equal true
+
 		describe "when the request returns an error status code", ->
 			beforeEach ->
 				@request.callsArgWith(1, null, {statusCode: 500}, "")
@@ -196,3 +222,5 @@ describe "PersistenceManager", ->
 			it "should time the execution", ->
 				@Metrics.Timer::done.called.should.equal true
 
+			it "should increment the metric", ->
+				@Metrics.inc.calledWith("setDoc", {status: 500}).should.equal true


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Add metrics for all successes/failures/retries in docupdater requests to web-api.

Currently we are only recording the time taken by the request, but not connection errors and retry attempts.  I want to know if any of these requests are failing and leading to out of sync errors in the client.

#### Screenshots

NA

#### Related Issues / PRs

NA

### Review

Small change,  adds metrics only.

#### Potential Impact

High, due to being in docupdater

#### Manual Testing Performed

- [x] Unit and acceptance tests 

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

- [ ] Create docupdater errors chart

#### Who Needs to Know?
