### PR TITLE
add comment about null byte check

### DIFF
--- a/app/coffee/RedisManager.coffee
+++ b/app/coffee/RedisManager.coffee
@@ -36,6 +36,8 @@ module.exports = RedisManager =
 		docLines = JSON.stringify(docLines)
 		if docLines.indexOf("\u0000") != -1
 			error = new Error("null bytes found in doc lines")
+			# this check was added to catch memory corruption in JSON.stringify.
+			# It sometimes returned null bytes at the end of the string.
 			logger.error {err: error, doc_id: doc_id, docLines: docLines}, error.message
 			return callback(error)
 		docHash = RedisManager._computeHash(docLines)
@@ -224,12 +226,14 @@ module.exports = RedisManager =
 			for op in jsonOps
 				if op.indexOf("\u0000") != -1
 					error = new Error("null bytes found in jsonOps")
+					# this check was added to catch memory corruption in JSON.stringify
 					logger.error {err: error, doc_id: doc_id, jsonOps: jsonOps}, error.message
 					return callback(error)
 
 			newDocLines = JSON.stringify(docLines)
 			if newDocLines.indexOf("\u0000") != -1
 				error = new Error("null bytes found in doc lines")
+				# this check was added to catch memory corruption in JSON.stringify
 				logger.error {err: error, doc_id: doc_id, newDocLines: newDocLines}, error.message
 				return callback(error)
 			newHash = RedisManager._computeHash(newDocLines)
@@ -243,6 +247,7 @@ module.exports = RedisManager =
 					return callback(error)
 				if ranges? and ranges.indexOf("\u0000") != -1
 					error = new Error("null bytes found in ranges")
+					# this check was added to catch memory corruption in JSON.stringify
 					logger.error err: error, doc_id: doc_id, ranges: ranges, error.message
 					return callback(error)
 				multi = rclient.multi()


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Add comments to explain why null byte checks were added in RedisManager for each JSON.stringify.
Original PRs are below - they didn't give the reason, I think it was an emergency fix.

#### Screenshots

NA

#### Related Issues / PRs

Original PRs
https://github.com/overleaf/document-updater/pull/21
https://github.com/overleaf/document-updater/pull/44

https://github.com/overleaf/issues/issues/2694
https://github.com/overleaf/document-updater/pull/110

### Review

Comments only.

#### Potential Impact

None

#### Manual Testing Performed

- [X] Unit and acceptance tests


#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

@das7pad @jdleesmiller 