### PR TITLE
remove unused redis settings from rate limit unit test

### DIFF
--- a/test/unit/coffee/RateLimitManager/RateLimitManager.coffee
+++ b/test/unit/coffee/RateLimitManager/RateLimitManager.coffee
@@ -9,9 +9,7 @@ describe "RateLimitManager", ->
 	beforeEach ->
 		@RateLimitManager = SandboxedModule.require modulePath, requires:
 			"logger-sharelatex": @logger = { log: sinon.stub() }
-			"settings-sharelatex": @settings =
-				redis:
-					realtime: {}
+			"settings-sharelatex": @settings = {}
 			"./Metrics": @Metrics =
 				Timer: class Timer
 					done: sinon.stub()


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Following on from #65 this removes an unnecessary use of the old real-time redis setting from the tests.

#### Screenshots

NA

#### Related Issues / PRs

#75

### Review

Unused setting.

#### Potential Impact

Tests only

#### Manual Testing Performed

- [X] Unit tests


#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

NA