### PR TITLE
use empty object for ranges if it doesn't exist

### DIFF
--- a/app/coffee/DocumentManager.coffee
+++ b/app/coffee/DocumentManager.coffee
@@ -30,7 +30,7 @@ module.exports = DocumentManager =
 						return callback(error) if error?
 						RedisManager.setHistoryType doc_id, projectHistoryType, (error) ->
 							return callback(error) if error?
-							callback null, lines, version, ranges, pathname, projectHistoryId, null, false
+							callback null, lines, version, ranges || {}, pathname, projectHistoryId, null, false
 			else
 				callback null, lines, version, ranges, pathname, projectHistoryId, unflushedTime, true
 


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description
Ensure's `DocumentManager.getDoc` is always supplied a `ranges` object, rather than sometimes being null. File changes proposed by @briangough in https://github.com/overleaf/issues/issues/2632#issuecomment-575086091.



#### Related Issues / PRs
fixes https://github.com/overleaf/issues/issues/2632



#### Manual Testing Performed
- [x] accessed and edited project
