### PR TITLE
Add ignore_flush_errors option to the doc delete endpoint

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -54,7 +54,7 @@ app.post   '/project/:project_id/get_and_flush_if_old',                 HttpCont
 app.post   '/project/:project_id/clearState',                           HttpController.clearProjectState
 app.post   '/project/:project_id/doc/:doc_id',                          HttpController.setDoc
 app.post   '/project/:project_id/doc/:doc_id/flush',                    HttpController.flushDocIfLoaded
-app.delete '/project/:project_id/doc/:doc_id',                          HttpController.flushAndDeleteDoc
+app.delete '/project/:project_id/doc/:doc_id',                          HttpController.deleteDoc
 app.delete '/project/:project_id',                                      HttpController.deleteProject
 app.delete '/project',                                                  HttpController.deleteMultipleProjects
 app.post   '/project/:project_id',                                      HttpController.updateProject

--- a/app/coffee/DocumentManager.coffee
+++ b/app/coffee/DocumentManager.coffee
@@ -222,6 +222,10 @@ module.exports = DocumentManager =
 		UpdateManager = require "./UpdateManager"
 		UpdateManager.lockUpdatesAndDo DocumentManager.flushAndDeleteDoc, project_id, doc_id, callback
 
+	deleteDocWithLock: (project_id, doc_id, callback) ->
+		UpdateManager = require "./UpdateManager"
+		UpdateManager.lockUpdatesAndDo RedisManager.removeDocFromMemory, project_id, doc_id, callback
+
 	acceptChangesWithLock: (project_id, doc_id, change_ids, callback = (error) ->) ->
 		UpdateManager = require "./UpdateManager"
 		UpdateManager.lockUpdatesAndDo DocumentManager.acceptChanges, project_id, doc_id, change_ids, callback

--- a/app/coffee/DocumentManager.coffee
+++ b/app/coffee/DocumentManager.coffee
@@ -91,7 +91,7 @@ module.exports = DocumentManager =
 							return callback(error) if error?
 							callback null
 					else
-						DocumentManager.flushAndDeleteDoc project_id, doc_id, (error) ->
+						DocumentManager.flushAndDeleteDoc project_id, doc_id, {}, (error) ->
 							# There is no harm in flushing project history if the previous
 							# call failed and sometimes it is required
 							HistoryManager.flushProjectChangesAsync project_id
@@ -115,14 +115,18 @@ module.exports = DocumentManager =
 					return callback(error) if error?
 					RedisManager.clearUnflushedTime doc_id, callback
 
-	flushAndDeleteDoc: (project_id, doc_id, _callback = (error) ->) ->
+	flushAndDeleteDoc: (project_id, doc_id, options, _callback) ->
 		timer = new Metrics.Timer("docManager.flushAndDeleteDoc")
 		callback = (args...) ->
 			timer.done()
 			_callback(args...)
 
 		DocumentManager.flushDocIfLoaded project_id, doc_id, (error) ->
-			return callback(error) if error?
+			if error?
+				if options.ignoreFlushErrors
+					logger.warn {project_id: project_id, doc_id: doc_id, err: error}, "ignoring flush error while deleting document"
+				else
+					return callback(error)
 
 			# Flush in the background since it requires a http request
 			HistoryManager.flushDocChangesAsync project_id, doc_id
@@ -218,13 +222,9 @@ module.exports = DocumentManager =
 		UpdateManager = require "./UpdateManager"
 		UpdateManager.lockUpdatesAndDo DocumentManager.flushDocIfLoaded, project_id, doc_id, callback
 
-	flushAndDeleteDocWithLock: (project_id, doc_id, callback = (error) ->) ->
+	flushAndDeleteDocWithLock: (project_id, doc_id, options, callback) ->
 		UpdateManager = require "./UpdateManager"
-		UpdateManager.lockUpdatesAndDo DocumentManager.flushAndDeleteDoc, project_id, doc_id, callback
-
-	deleteDocWithLock: (project_id, doc_id, callback) ->
-		UpdateManager = require "./UpdateManager"
-		UpdateManager.lockUpdatesAndDo RedisManager.removeDocFromMemory, project_id, doc_id, callback
+		UpdateManager.lockUpdatesAndDo DocumentManager.flushAndDeleteDoc, project_id, doc_id, options, callback
 
 	acceptChangesWithLock: (project_id, doc_id, change_ids, callback = (error) ->) ->
 		UpdateManager = require "./UpdateManager"

--- a/app/coffee/ProjectManager.coffee
+++ b/app/coffee/ProjectManager.coffee
@@ -52,7 +52,7 @@ module.exports = ProjectManager =
 			for doc_id in (doc_ids or [])
 				do (doc_id) ->
 					jobs.push (callback) ->
-						DocumentManager.flushAndDeleteDocWithLock project_id, doc_id, (error) ->
+						DocumentManager.flushAndDeleteDocWithLock project_id, doc_id, {}, (error) ->
 							if error?
 								logger.error err: error, project_id: project_id, doc_id: doc_id, "error deleting doc"
 								errors.push(error)

--- a/test/unit/coffee/HttpController/HttpControllerTests.coffee
+++ b/test/unit/coffee/HttpController/HttpControllerTests.coffee
@@ -271,7 +271,7 @@ describe "HttpController", ->
 				params:
 					project_id: @project_id
 					doc_id: @doc_id
-				body: {}
+				query: {}
 
 		describe "successfully", ->
 			beforeEach ->
@@ -295,7 +295,7 @@ describe "HttpController", ->
 
 			it "should log the request", ->
 				@logger.log
-					.calledWith(doc_id: @doc_id, project_id: @project_id, flush: true, "deleting doc via http")
+					.calledWith(doc_id: @doc_id, project_id: @project_id, "deleting doc via http")
 					.should.equal true
 
 			it "should time the request", ->
@@ -303,7 +303,7 @@ describe "HttpController", ->
 
 		describe "without flush", ->
 			beforeEach ->
-				@req.body.flush = false
+				@req.query.skip_flush = 'true'
 				@DocumentManager.deleteDocWithLock = sinon.stub().yields()
 				@HttpController.deleteDoc(@req, @res, @next)
 

--- a/test/unit/coffee/ProjectManager/flushAndDeleteProjectTests.coffee
+++ b/test/unit/coffee/ProjectManager/flushAndDeleteProjectTests.coffee
@@ -23,7 +23,7 @@ describe "ProjectManager - flushAndDeleteProject", ->
 		beforeEach (done) ->
 			@doc_ids = ["doc-id-1", "doc-id-2", "doc-id-3"]
 			@RedisManager.getDocIdsInProject = sinon.stub().callsArgWith(1, null, @doc_ids)
-			@DocumentManager.flushAndDeleteDocWithLock = sinon.stub().callsArg(2)
+			@DocumentManager.flushAndDeleteDocWithLock = sinon.stub().callsArg(3)
 			@ProjectManager.flushAndDeleteProjectWithLocks @project_id, {}, (error) =>
 				@callback(error)
 				done()
@@ -36,7 +36,7 @@ describe "ProjectManager - flushAndDeleteProject", ->
 		it "should delete each doc in the project", ->
 			for doc_id in @doc_ids
 				@DocumentManager.flushAndDeleteDocWithLock
-					.calledWith(@project_id, doc_id)
+					.calledWith(@project_id, doc_id, {})
 					.should.equal true
 
 		it "should flush project history", ->
@@ -54,7 +54,7 @@ describe "ProjectManager - flushAndDeleteProject", ->
 		beforeEach (done) ->
 			@doc_ids = ["doc-id-1", "doc-id-2", "doc-id-3"]
 			@RedisManager.getDocIdsInProject = sinon.stub().callsArgWith(1, null, @doc_ids)
-			@DocumentManager.flushAndDeleteDocWithLock = sinon.spy (project_id, doc_id, callback = (error) ->) =>
+			@DocumentManager.flushAndDeleteDocWithLock = sinon.spy (project_id, doc_id, options, callback) =>
 				if doc_id == "doc-id-1"
 					callback(@error = new Error("oops, something went wrong"))
 				else
@@ -66,7 +66,7 @@ describe "ProjectManager - flushAndDeleteProject", ->
 		it "should still flush each doc in the project", ->
 			for doc_id in @doc_ids
 				@DocumentManager.flushAndDeleteDocWithLock
-					.calledWith(@project_id, doc_id)
+					.calledWith(@project_id, doc_id, {})
 					.should.equal true
 
 		it "should still flush project history", ->


### PR DESCRIPTION
### Description

This will delete the document from Redis without flushing to web,
docstore or history. To be used when something is broken.

#### Related Issues / PRs

* https://github.com/overleaf/issues/issues/2726

### Review



#### Potential Impact

* Document deletion

#### Manual Testing Performed

- [x] Delete a document via the editor
- [x] Do a non-flushing delete and observe the doc being removed from Redis