### PR TITLE
[misc] add monitoring for redis pub/sub

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -79,6 +79,14 @@ app.get '/status', (req, res)->
 	else
 		res.send('document updater is alive')
 
+app.post '/monitor-redis-pub-sub/enable', (req, res) ->
+	require('./monitorRedisPubSub').enable(req.query.per_channel == 'true')
+	res.send(204)
+
+app.post '/monitor-redis-pub-sub/disable', (req, res) ->
+	require('./monitorRedisPubSub').disable()
+	res.send(204)
+
 pubsubClient = require("redis-sharelatex").createClient(Settings.redis.pubsub)
 app.get "/health_check/redis", (req, res, next) ->
 	pubsubClient.healthCheck (error) ->

--- a/monitorRedisPubSub.js
+++ b/monitorRedisPubSub.js
@@ -1,0 +1,55 @@
+const Metrics = require('metrics-sharelatex')
+const Redis = require('redis-sharelatex')
+const Settings = require('settings-sharelatex')
+
+const clients = new Map()
+
+module.exports = {
+  enable: function(per_channel) {
+    subscribeTo('applied-ops', per_channel)
+    subscribeTo('editor-events', per_channel)
+  },
+  disable: function() {
+    unsubscribeFrom('applied-ops')
+    unsubscribeFrom('editor-events')
+  }
+}
+
+function unsubscribeFrom(key) {
+  if (!clients.has(key)) {
+    return
+  }
+
+  console.warn(`disabling pub/sub monitor for ${key}`)
+  const pubsubClient = clients.get(key)
+  clients.delete(key)
+
+  pubsubClient.punsubscribe(`${key}:*`)
+  pubsubClient.unsubscribe(key)
+}
+
+function subscribeTo(key, per_channel) {
+  if (clients.has(key)) {
+    return
+  }
+
+  console.warn(`enabling pub/sub monitor for ${key}`)
+  const pubsubClient = Redis.createClient(Settings.redis.pubsub)
+  clients.set(key, pubsubClient)
+
+  pubsubClient.psubscribe(`${key}:*`)
+  pubsubClient.on('pmessage', (pattern, channel, blob) => {
+    processBlob(channel, blob)
+  })
+
+  pubsubClient.subscribe(key)
+  pubsubClient.on('message', processBlob)
+
+  function processBlob(channel, blob) {
+    const opts = {}
+    if (per_channel) {
+      opts.channel = channel
+    }
+    Metrics.summary(`redis_pub_sub_${key}`, blob.length, opts)
+  }
+}


### PR DESCRIPTION
### Description

Targets #127 (which includes a bump of the metrics version to 2.6, needed for `Metrics.summary`)

This PR enables tracking of pub/sub message sizes.
There is no point in pulling pub/sub messages on all pods and reporting
 the _exact same_ data, so this has to be enabled manually.


New routes are added for enabling/disabling of monitoring on a single
 pod.

- /monitor-redis-pub-sub/enable

  optional URL query parameter: `per_channel=true`, default false

- /monitor-redis-pub-sub/disable

Attaches pub/sub message handler and tracks the size of the blobs in a
 new metric.

- applied-ops -> redis_pub_sub_applied_ops
- editor-events -> redis_pub_sub_editor_events

Some messages are broad casted on more specific channels and the
 exact channel may be added as a tag to the metric. To do that specify
 `per_channel=true` when enabling the monitoring.

#### Screenshots

<details>

<pre>
$ curl -sS http://127.0.0.1:3003/metrics | grep redis_pub_sub
# HELP redis_pub_sub_applied_ops redis_pub_sub_applied_ops
# TYPE redis_pub_sub_applied_ops summary
redis_pub_sub_applied_ops{quantile="0.01",channel="applied-ops:5e5e60ad7f85bc0026992b26",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_applied_ops{quantile="0.05",channel="applied-ops:5e5e60ad7f85bc0026992b26",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_applied_ops{quantile="0.5",channel="applied-ops:5e5e60ad7f85bc0026992b26",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_applied_ops{quantile="0.9",channel="applied-ops:5e5e60ad7f85bc0026992b26",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_applied_ops{quantile="0.95",channel="applied-ops:5e5e60ad7f85bc0026992b26",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_applied_ops{quantile="0.99",channel="applied-ops:5e5e60ad7f85bc0026992b26",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_applied_ops{quantile="0.999",channel="applied-ops:5e5e60ad7f85bc0026992b26",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_applied_ops_sum{channel="applied-ops:5e5e60ad7f85bc0026992b26",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 350
redis_pub_sub_applied_ops_count{channel="applied-ops:5e5e60ad7f85bc0026992b26",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 1
redis_pub_sub_applied_ops{quantile="0.01",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 298
redis_pub_sub_applied_ops{quantile="0.05",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 298
redis_pub_sub_applied_ops{quantile="0.5",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 302
redis_pub_sub_applied_ops{quantile="0.9",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 350
redis_pub_sub_applied_ops{quantile="0.95",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 350
redis_pub_sub_applied_ops{quantile="0.99",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 350
redis_pub_sub_applied_ops{quantile="0.999",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 350
redis_pub_sub_applied_ops_sum{app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 950
redis_pub_sub_applied_ops_count{app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 3
# HELP redis_pub_sub_editor_events redis_pub_sub_editor_events
# TYPE redis_pub_sub_editor_events summary
redis_pub_sub_editor_events{quantile="0.01",channel="editor-events:5e5e60ad7f85bc0026992b25",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_editor_events{quantile="0.05",channel="editor-events:5e5e60ad7f85bc0026992b25",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_editor_events{quantile="0.5",channel="editor-events:5e5e60ad7f85bc0026992b25",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_editor_events{quantile="0.9",channel="editor-events:5e5e60ad7f85bc0026992b25",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_editor_events{quantile="0.95",channel="editor-events:5e5e60ad7f85bc0026992b25",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_editor_events{quantile="0.99",channel="editor-events:5e5e60ad7f85bc0026992b25",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_editor_events{quantile="0.999",channel="editor-events:5e5e60ad7f85bc0026992b25",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_editor_events_sum{channel="editor-events:5e5e60ad7f85bc0026992b25",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 484
redis_pub_sub_editor_events_count{channel="editor-events:5e5e60ad7f85bc0026992b25",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 3
redis_pub_sub_editor_events{quantile="0.01",channel="editor-events",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_editor_events{quantile="0.05",channel="editor-events",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_editor_events{quantile="0.5",channel="editor-events",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_editor_events{quantile="0.9",channel="editor-events",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_editor_events{quantile="0.95",channel="editor-events",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_editor_events{quantile="0.99",channel="editor-events",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_editor_events{quantile="0.999",channel="editor-events",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 0
redis_pub_sub_editor_events_sum{channel="editor-events",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 6407
redis_pub_sub_editor_events_count{channel="editor-events",app="doc-updater",host="2744ce1b0377",path="",status_code="",method="",collection="",query=""} 1
</pre>
</details>

#### Review

_Sorry, this is written in plain JavaScript._

#### Potential Impact

Low. Higher bandwidth usage on a single pod, when activated.


#### Manual Testing Performed

- enable monitoring:

   `$ curl -X POST http://127.0.0.1:3003/monitor-redis-pub-sub/enable`

- make edits in the editor
- see bumped metrics:

   `$ curl -sS http://127.0.0.1:3003/metrics | grep redis_pub_sub`
- disable monitoring

   `$ curl -X POST http://127.0.0.1:3003/monitor-redis-pub-sub/disable`
- make edits in the editor
- see the same metrics:

  `$ curl -sS http://127.0.0.1:3003/metrics | grep redis_pub_sub`
- enable monitoring in verbose mode

   `$ curl -X POST http://127.0.0.1:3003/monitor-redis-pub-sub/enable?per_channel=true`
- make edits in the editor
- see the verbose metrics (specific channels `,channel="applied-ops:..."`):

   `$ curl -sS http://127.0.0.1:3003/metrics | grep redis_pub_sub`


#### Metrics and Monitoring

`redis_pub_sub_applied_ops` and `redis_pub_sub_editor_events`
