### PR TITLE
[misc] track redis pub/sub payload sizes on publish

### DIFF
--- a/app/coffee/RealTimeRedisManager.coffee
+++ b/app/coffee/RealTimeRedisManager.coffee
@@ -39,9 +39,13 @@ module.exports = RealTimeRedisManager =
 		# create a unique message id using a counter
 		message_id = "doc:#{HOST}:#{RND}-#{COUNT++}"
 		data?._id = message_id
+
+		blob = JSON.stringify(data)
+		metrics.summary "redis.publish.applied-ops", blob.length
+
 		# publish on separate channels for individual projects and docs when
 		# configured (needs realtime to be configured for this too).
 		if Settings.publishOnIndividualChannels
-			pubsubClient.publish "applied-ops:#{data.doc_id}", JSON.stringify(data)
+			pubsubClient.publish "applied-ops:#{data.doc_id}", blob
 		else
-			pubsubClient.publish "applied-ops", JSON.stringify(data)
+			pubsubClient.publish "applied-ops", blob

--- a/test/unit/coffee/RealTimeRedisManager/RealTimeRedisManagerTests.coffee
+++ b/test/unit/coffee/RealTimeRedisManager/RealTimeRedisManagerTests.coffee
@@ -90,3 +90,6 @@ describe "RealTimeRedisManager", ->
 
 		it "should send the op with a message id", ->
 			@pubsubClient.publish.calledWith("applied-ops", JSON.stringify({op:"thisop",_id:@message_id})).should.equal true
+
+		it "should track the payload size", ->
+			@metrics.summary.calledWith("redis.publish.applied-ops", JSON.stringify({op:"thisop",_id:@message_id}).length).should.equal true


### PR DESCRIPTION
### Description

Better way of doing https://github.com/overleaf/document-updater/pull/128 aka tracking payload sizes of redis pub/sub messages.

https://github.com/overleaf/document-updater/pull/128#pullrequestreview-382171208

> I think it would make more sense to add metrics at the point where we publish the message. This is simpler and we know that we are only counting them once.

#### Related Issues / PRs

#127


### Review

Targets #127 (which includes a bump of the metrics version to 2.6, needed for `Metrics.summary`)

#### Potential Impact
Low


#### Manual Testing Performed

- added unit test

#### Metrics and Monitoring

`redis.publish.applied-ops`
