### PR TITLE
Set the diff-match-patch timeout to 100ms

### DIFF
--- a/app/js/DiffCodec.js
+++ b/app/js/DiffCodec.js
@@ -1,6 +1,9 @@
 const DMP = require('diff-match-patch')
 const dmp = new DMP()
 
+// Do not attempt to produce a diff for more than 100ms
+dmp.Diff_Timeout = 0.1
+
 module.exports = {
   ADDED: 1,
   REMOVED: -1,


### PR DESCRIPTION
### Description

This might result in worse diffs, but we don't want to spend a second blocking the event loop while we figure out nicer diffs when comparing documents.

#### Related Issues / PRs

Issue: https://github.com/overleaf/issues/issues/615

### Review



#### Potential Impact

This might change the diffs that are sent to document updater when reconciling an uploaded document with the previous version. As far as I can tell, these diffs are not user-visible and are only meant to propagate changes to collaborators.

#### Manual Testing Performed

With a project opened in two tabs:
- [x] Upload a document over an existing document.
- [x] Check that the document was correctly updated in both tabs
- [x] Look at the text operations sent through the websocket and confirm that they are a reasonable diff

### Deployment



#### Metrics and Monitoring

The prometheus library provides a metric called `nodejs_eventloop_lag_seconds` that measures the time it takes to go around the event loop. It's already low and not very spiky, so we might not see a visible difference.
