### PR TITLE
shard the pending-updates-list queue

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,7 +34,7 @@ app.use(Metrics.http.monitor(logger))
 app.use(bodyParser.json({ limit: Settings.maxJsonRequestSize }))
 Metrics.injectMetricsRoute(app)
 
-DispatchManager.createAndStartDispatchers(Settings.dispatcherCount || 10)
+DispatchManager.createAndStartDispatchers(Settings.dispatcherCount)
 
 app.param('project_id', (req, res, next, projectId) => {
   if (projectId != null && projectId.match(/^[0-9a-f]{24}$/)) {

--- a/app/js/DispatchManager.js
+++ b/app/js/DispatchManager.js
@@ -110,5 +110,10 @@ module.exports = DispatchManager = {
     _.times(number, function (shardNumber) {
       return DispatchManager.createDispatcher(RateLimiter, shardNumber).run()
     })
+
+    // run extra dispatchers on old queue while we migrate
+    _.times(number, function () {
+      return DispatchManager.createDispatcher(RateLimiter, 0).run()
+    })
   }
 }

--- a/app/js/DispatchManager.js
+++ b/app/js/DispatchManager.js
@@ -107,11 +107,8 @@ module.exports = DispatchManager = {
 
   createAndStartDispatchers(number) {
     const RateLimiter = new RateLimitManager(number)
-    return (() => {
-      const result = _.times(number, function (shardNumber) {
-        return DispatchManager.createDispatcher(RateLimiter, shardNumber).run()
-      })
-      return result
-    })()
+    _.times(number, function (shardNumber) {
+      return DispatchManager.createDispatcher(RateLimiter, shardNumber).run()
+    })
   }
 }

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -171,7 +171,7 @@ module.exports = {
   maxJsonRequestSize:
     parseInt(process.env.MAX_JSON_REQUEST_SIZE, 10) || 8 * 1024 * 1024,
 
-  dispatcherCount: process.env.DISPATCHER_COUNT,
+  dispatcherCount: process.env.DISPATCHER_COUNT || 10,
 
   mongo: {
     options: {

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -171,7 +171,7 @@ module.exports = {
   maxJsonRequestSize:
     parseInt(process.env.MAX_JSON_REQUEST_SIZE, 10) || 8 * 1024 * 1024,
 
-  dispatcherCount: process.env.DISPATCHER_COUNT || 10,
+  dispatcherCount: parseInt(process.env.DISPATCHER_COUNT || 10, 10)
 
   mongo: {
     options: {

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -171,7 +171,7 @@ module.exports = {
   maxJsonRequestSize:
     parseInt(process.env.MAX_JSON_REQUEST_SIZE, 10) || 8 * 1024 * 1024,
 
-  dispatcherCount: parseInt(process.env.DISPATCHER_COUNT || 10, 10)
+  dispatcherCount: parseInt(process.env.DISPATCHER_COUNT || 10, 10),
 
   mongo: {
     options: {

--- a/test/acceptance/js/helpers/DocUpdaterClient.js
+++ b/test/acceptance/js/helpers/DocUpdaterClient.js
@@ -28,7 +28,7 @@ module.exports = DocUpdaterClient = {
   },
 
   _getPendingUpdateListKey() {
-    const shard = _.random(0, Settings.dispatcherCount)
+    const shard = _.random(0, Settings.dispatcherCount - 1)
     if (shard === 0) {
       return 'pending-updates-list'
     } else {


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description
Breaks the `pending-updates-list` queue into 10 queues `pending-updates-list-${n}` while treating `pending-updates-list-0` as `pending-updates-list`

This should allow redis to share the load a bit more evenly over the different hosts.

I've just generated a random number when picking which queue to push onto, but a ensured an even distribution of workers to read from the queues.

It wouldn't be too hard to do some form of consistent hash based on the doc_id when deciding what queue to push onto, I don't think it is required and I don't think it will improve performance or load in any way so I decided to leave it.

 


#### Screenshots



#### Related Issues / PRs
https://github.com/overleaf/issues/issues/3955


### Review



#### Potential Impact
High - is ops are not processed it will cause the editor to break


#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment


#### Deployment Checklist

- [ ] Deploy canary to staging, test multiple docs with chaos monkey
- [ ] Deploy fully to staging
- [ ] Deploy canary to production, test multiple docs with chaos monkey
- [ ] Deploy fully to production

#### Metrics and Monitoring



#### Who Needs to Know?
@gh2k 
