### PR TITLE
add Dispatchers running on old queue while we migrate

### DIFF
--- a/app/js/DispatchManager.js
+++ b/app/js/DispatchManager.js
@@ -110,5 +110,10 @@ module.exports = DispatchManager = {
     _.times(number, function (shardNumber) {
       return DispatchManager.createDispatcher(RateLimiter, shardNumber).run()
     })
+
+    // run extra dispatchers on old queue while we migrate
+    _.times(number, function () {
+      return DispatchManager.createDispatcher(RateLimiter, 0).run()
+    })
   }
 }


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description
The will add extra dispatchers to listen and process on the old queue for the migration.  It can be reverted once we are fully migrated.


#### Screenshots



#### Related Issues / PRs
https://github.com/overleaf/document-updater/pull/156


### Review



#### Potential Impact

medium  - it increases the number of redis clients

#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
