### PR TITLE
stop listening on the pending updates channels 10 times

### DIFF
--- a/app/js/DispatchManager.js
+++ b/app/js/DispatchManager.js
@@ -110,10 +110,5 @@ module.exports = DispatchManager = {
     _.times(number, function (shardNumber) {
       return DispatchManager.createDispatcher(RateLimiter, shardNumber).run()
     })
-
-    // run extra dispatchers on old queue while we migrate
-    _.times(number, function () {
-      return DispatchManager.createDispatcher(RateLimiter, 0).run()
-    })
   }
 }


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description
Stops the 10 listeners on the old pending-updates list in redis, now the key is sharded we no longer need this fallback.

It will drop the number of open connections to redis.

Once this is deployed we will not be able to rollback to the old real time without adding this code back in. 

Because the new real time still has 1 worker on the old queue we can have a few users stuck on the old real time service without breaking functionality.

I've not yet had confirmation from redis-labs that the sharding has had the expected effect on load so will hold off deploying until then.

#### Screenshots
Almost all users are on the new real time now.

![2021-02-23 at 09 09](https://user-images.githubusercontent.com/343366/108822346-dbf9a200-75b6-11eb-9e6a-cb344bed31a3.png)



#### Related Issues / PRs
https://github.com/overleaf/issues/issues/3955


### Review



#### Potential Impact
low - 95% of users are on the new sharded key now


#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment
- rake deploy:app[env,document-updater,master,latest]


#### Deployment Checklist

- [ ] check updates in editor are still processing

#### Metrics and Monitoring



#### Who Needs to Know?
