### PR TITLE
Fix API request errors which could contain API hostname or address

### DIFF
--- a/app/js/PersistenceManager.js
+++ b/app/js/PersistenceManager.js
@@ -69,10 +69,10 @@ module.exports = PersistenceManager = {
       return _callback(...Array.from(args || []))
     }
 
-    const url = `${Settings.apis.web.url}/project/${project_id}/doc/${doc_id}`
+    const urlPath = `/project/${project_id}/doc/${doc_id}`
     return request(
       {
-        url,
+        url: `${Settings.apis.web.url}${urlPath}`,
         method: 'GET',
         headers: {
           accept: 'application/json'
@@ -88,7 +88,11 @@ module.exports = PersistenceManager = {
       function (error, res, body) {
         updateMetric('getDoc', error, res)
         if (error != null) {
-          return callback(error)
+          logger.error(
+            { err: error, project_id, doc_id },
+            'web API request failed'
+          )
+          return callback(new Error('error connecting to web API'))
         }
         if (res.statusCode >= 200 && res.statusCode < 300) {
           try {
@@ -119,10 +123,12 @@ module.exports = PersistenceManager = {
             body.projectHistoryType
           )
         } else if (res.statusCode === 404) {
-          return callback(new Errors.NotFoundError(`doc not not found: ${url}`))
+          return callback(
+            new Errors.NotFoundError(`doc not not found: ${urlPath}`)
+          )
         } else {
           return callback(
-            new Error(`error accessing web API: ${url} ${res.statusCode}`)
+            new Error(`error accessing web API: ${urlPath} ${res.statusCode}`)
           )
         }
       }
@@ -148,10 +154,10 @@ module.exports = PersistenceManager = {
       return _callback(...Array.from(args || []))
     }
 
-    const url = `${Settings.apis.web.url}/project/${project_id}/doc/${doc_id}`
+    const urlPath = `/project/${project_id}/doc/${doc_id}`
     return request(
       {
-        url,
+        url: `${Settings.apis.web.url}${urlPath}`,
         method: 'POST',
         json: {
           lines,
@@ -171,15 +177,21 @@ module.exports = PersistenceManager = {
       function (error, res, body) {
         updateMetric('setDoc', error, res)
         if (error != null) {
-          return callback(error)
+          logger.error(
+            { err: error, project_id, doc_id },
+            'web API request failed'
+          )
+          return callback(new Error('error connecting to web API'))
         }
         if (res.statusCode >= 200 && res.statusCode < 300) {
           return callback(null)
         } else if (res.statusCode === 404) {
-          return callback(new Errors.NotFoundError(`doc not not found: ${url}`))
+          return callback(
+            new Errors.NotFoundError(`doc not not found: ${urlPath}`)
+          )
         } else {
           return callback(
-            new Error(`error accessing web API: ${url} ${res.statusCode}`)
+            new Error(`error accessing web API: ${urlPath} ${res.statusCode}`)
           )
         }
       }

--- a/test/unit/js/PersistenceManager/PersistenceManagerTests.js
+++ b/test/unit/js/PersistenceManager/PersistenceManagerTests.js
@@ -40,7 +40,8 @@ describe('PersistenceManager', function () {
         }),
         'logger-sharelatex': (this.logger = {
           log: sinon.stub(),
-          err: sinon.stub()
+          err: sinon.stub(),
+          error: sinon.stub()
         }),
         './Errors': Errors
       }
@@ -145,8 +146,14 @@ describe('PersistenceManager', function () {
         )
       })
 
-      it('should return the error', function () {
-        return this.callback.calledWith(this.error).should.equal(true)
+      it('should return a generic connection error', function () {
+        return this.callback
+          .calledWith(
+            sinon.match
+              .instanceOf(Error)
+              .and(sinon.match.has('message', 'error connecting to web API'))
+          )
+          .should.equal(true)
       })
 
       it('should time the execution', function () {
@@ -355,8 +362,14 @@ describe('PersistenceManager', function () {
         )
       })
 
-      it('should return the error', function () {
-        return this.callback.calledWith(this.error).should.equal(true)
+      it('should return a generic connection error', function () {
+        return this.callback
+          .calledWith(
+            sinon.match
+              .instanceOf(Error)
+              .and(sinon.match.has('message', 'error connecting to web API'))
+          )
+          .should.equal(true)
       })
 
       it('should time the execution', function () {


### PR DESCRIPTION
### Description

Failing requests from document-updater to web could pass errors through real-time and back to the client which contained API hostnames/addresses. Instead of propagating the raw thrown error, wrap errors produced by failing requests, and remove the url/hostname from thrown error messages.

#### Related Issues / PRs

For overleaf/issues#3768

#### Potential Impact

Low

#### Manual Testing Performed

- [ ] Force network error by killing web, check behaviour is correct and websocket message is a generic connection error
