### PR TITLE
[perf] use MGET for fetching multiple keys in one operation

### DIFF
--- a/app/js/RedisManager.js
+++ b/app/js/RedisManager.js
@@ -190,18 +190,19 @@ module.exports = RedisManager = {
       ) {}
     }
     const timer = new metrics.Timer('redis.get-doc')
-    const multi = rclient.multi()
-    multi.get(keys.docLines({ doc_id }))
-    multi.get(keys.docVersion({ doc_id }))
-    multi.get(keys.docHash({ doc_id }))
-    multi.get(keys.projectKey({ doc_id }))
-    multi.get(keys.ranges({ doc_id }))
-    multi.get(keys.pathname({ doc_id }))
-    multi.get(keys.projectHistoryId({ doc_id }))
-    multi.get(keys.unflushedTime({ doc_id }))
-    multi.get(keys.lastUpdatedAt({ doc_id }))
-    multi.get(keys.lastUpdatedBy({ doc_id }))
-    return multi.exec(function (error, ...rest) {
+    const collectKeys = [
+      keys.docLines({ doc_id }),
+      keys.docVersion({ doc_id }),
+      keys.docHash({ doc_id }),
+      keys.projectKey({ doc_id }),
+      keys.ranges({ doc_id }),
+      keys.pathname({ doc_id }),
+      keys.projectHistoryId({ doc_id }),
+      keys.unflushedTime({ doc_id }),
+      keys.lastUpdatedAt({ doc_id }),
+      keys.lastUpdatedBy({ doc_id })
+    ]
+    rclient.mget(...collectKeys, (error, ...rest) => {
       let [
         docLines,
         version,


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/4154
Minimal version of https://github.com/overleaf/document-updater/pull/163

This PR is migrating the MULTI pipeline in getDoc to a single MGET command.
It reduces the number of Operations for getDoc from 13 to 2.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/4154
Minimal version of https://github.com/overleaf/document-updater/pull/163

#### Potential Impact

High. All document updates go through this code path.

#### Manual Testing Performed

- run acceptance tests
