### PR TITLE
upgrade ioredis via @overleaf/redis-wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -904,16 +904,26 @@
       }
     },
     "@overleaf/o-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@overleaf/o-error/-/o-error-3.1.0.tgz",
-      "integrity": "sha512-TWJ80ozJ1LeugGTJyGQSPEuTkZ9LqZD7/ndLE6azKa03SU/mKV/FINcfk8atpVil8iv1hHQwzYZc35klplpMpQ=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@overleaf/o-error/-/o-error-3.3.1.tgz",
+      "integrity": "sha512-1FRBYZO0lbJ0U+FRGZVS8ou6RhEw3e2B86WW/NbtBw554g0h5iC8ESf+juIfPMU/WDf/JDIFbg3eB/LnP2RSow==",
+      "requires": {
+        "core-js": "^3.8.3"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.11.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.1.tgz",
+          "integrity": "sha512-k93Isqg7e4txZWMGNYwevZL9MiogLk8pd1PtwrmFmi8IBq4GXqUaVW/a33Llt6amSI36uSjd0GWwc9pTT9ALlQ=="
+        }
+      }
     },
     "@overleaf/redis-wrapper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@overleaf/redis-wrapper/-/redis-wrapper-2.0.0.tgz",
-      "integrity": "sha512-lREuhDPNgmKyOmL1g6onfRzDLWOG/POsE4Vd7ZzLnKDYt9SbOIujtx3CxI2qtQAKBYHf/hfyrbtyX3Ib2yTvYA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@overleaf/redis-wrapper/-/redis-wrapper-2.0.1.tgz",
+      "integrity": "sha512-1TwCbEKJFz2yUhmwy2hQzy04NBhnseT371X2AU2szkNJ8Ip1C1HwJt1UAK/7Nh+hY7kFfH7Qpk+bZUF9f/rUMQ==",
       "requires": {
-        "ioredis": "~4.17.3"
+        "ioredis": "~4.27.1"
       }
     },
     "@protobufjs/aspromise": {
@@ -1534,9 +1544,9 @@
       "dev": true
     },
     "bson": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -1924,9 +1934,9 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "denque": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-      "integrity": "sha1-Z0T/dkHBSMP4ppwwflEjXB9KN88="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -3532,25 +3542,26 @@
       }
     },
     "ioredis": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.17.3.tgz",
-      "integrity": "sha512-iRvq4BOYzNFkDnSyhx7cmJNOi1x/HWYe+A4VXHBu4qpwJaGT1Mp+D2bVGJntH9K/Z/GeOM/Nprb8gB3bmitz1Q==",
+      "version": "4.27.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.27.1.tgz",
+      "integrity": "sha512-PaFNFeBbOcEYHXAdrJuy7uesJcyvzStTM1aYMchTuky+VgKqDbXhnTJHaDsjAwcTwPx8Asatx+l2DW8zZ2xlsQ==",
       "requires": {
         "cluster-key-slot": "^1.1.0",
-        "debug": "^4.1.1",
+        "debug": "^4.3.1",
         "denque": "^1.1.0",
         "lodash.defaults": "^4.2.0",
         "lodash.flatten": "^4.4.0",
-        "redis-commands": "1.5.0",
+        "p-map": "^2.1.0",
+        "redis-commands": "1.7.0",
         "redis-errors": "^1.2.0",
         "redis-parser": "^3.0.0",
-        "standard-as-callback": "^2.0.1"
+        "standard-as-callback": "^2.1.0"
       },
       "dependencies": {
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -3819,9 +3830,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -4469,14 +4480,14 @@
       "optional": true
     },
     "mongodb": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.0.tgz",
-      "integrity": "sha512-/XWWub1mHZVoqEsUppE0GV7u9kanLvHxho6EvBxQbShXTKYF9trhZC2NzbulRGeG7xMJHD8IOWRcdKx5LPjAjQ==",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.6.tgz",
+      "integrity": "sha512-WlirMiuV1UPbej5JeCMqE93JRfZ/ZzqE7nJTwP85XzjAF4rRSeq2bGCb1cjfoHLOF06+HxADaPGqT0g3SbVT1w==",
       "requires": {
-        "bl": "^2.2.0",
+        "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "require_optional": "^1.0.1",
+        "optional-require": "^1.0.2",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       }
@@ -4839,6 +4850,11 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "optional-require": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
+      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
+    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -4889,6 +4905,11 @@
       "requires": {
         "p-limit": "^2.0.0"
       }
+    },
+    "p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
     "p-try": {
       "version": "2.2.0",
@@ -5907,9 +5928,9 @@
       }
     },
     "redis-commands": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
-      "integrity": "sha1-gNLiBpj+aI8icSf/nlFkp90X54U="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
     },
     "redis-errors": {
       "version": "1.2.0",
@@ -5998,12 +6019,12 @@
       }
     },
     "requestretry": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-4.1.0.tgz",
-      "integrity": "sha512-q3IT2vz5vkcMT6xgwB/BWzsmnu7N/27l9fW86U48gt9Mwrce5rSEyFvpAW7Il1/B78/NBUlYBvcCY1RzWUWy7w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-4.1.2.tgz",
+      "integrity": "sha512-N1WAp+8eOy8NfsVBChcSxNCKvPY1azOpliQ4Sby4WDe0HFEhdKywlNZeROMBQ+BI3Jpc0eNOT1KVFGREawtahA==",
       "requires": {
         "extend": "^3.0.2",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.15",
         "when": "^3.7.7"
       }
     },
@@ -6056,22 +6077,6 @@
       "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
       "dev": true
     },
-    "require_optional": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha1-TPNaQkf2TKPfjC7yCMxJSxyo/C4=",
-      "requires": {
-        "resolve-from": "^2.0.0",
-        "semver": "^5.1.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
-    },
     "resolve": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
@@ -6079,11 +6084,6 @@
       "requires": {
         "path-parse": "^1.0.6"
       }
-    },
-    "resolve-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "restore-cursor": {
       "version": "3.1.0",
@@ -6246,9 +6246,9 @@
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "settings-sharelatex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/settings-sharelatex/-/settings-sharelatex-1.1.0.tgz",
-      "integrity": "sha1-Tv4vUpPbjxwVlnEEx5BfqHD/mS0=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/settings-sharelatex/-/settings-sharelatex-1.3.0.tgz",
+      "integrity": "sha512-AWSeCiY1eHi+z6DF4bmTyC3tusOc6EF5zDkC28aAOhEAbgVEIuY034kx1X7a4j9HE0iVs0sVOlZrQMWJBVk3oQ==",
       "requires": {
         "coffee-script": "1.6.0"
       },
@@ -6445,9 +6445,9 @@
       "dev": true
     },
     "standard-as-callback": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.0.1.tgz",
-      "integrity": "sha1-7YuyVkjhWDF1m2Ajvbh+a2CzgSY="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "statuses": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -19,19 +19,19 @@
   },
   "dependencies": {
     "@overleaf/metrics": "^3.5.1",
-    "@overleaf/o-error": "^3.1.0",
-    "@overleaf/redis-wrapper": "^2.0.0",
+    "@overleaf/o-error": "^3.3.1",
+    "@overleaf/redis-wrapper": "^2.0.1",
     "async": "^2.5.0",
     "body-parser": "^1.19.0",
     "bunyan": "~0.22.1",
     "diff-match-patch": "https://github.com/overleaf/diff-match-patch/archive/89805f9c671a77a263fc53461acd62aa7498f688.tar.gz",
     "express": "4.17.1",
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.21",
     "logger-sharelatex": "^2.2.0",
-    "mongodb": "^3.6.0",
+    "mongodb": "^3.6.6",
     "request": "^2.88.2",
-    "requestretry": "^4.1.0",
-    "settings-sharelatex": "^1.1.0"
+    "requestretry": "^4.1.2",
+    "settings-sharelatex": "^1.3.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Upgrade to ioredis 4.27.1 via @overleaf/redis-wrapper, also update other dependencies.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3621

### Review

npm upgrades only and `make format_fix`

#### Potential Impact

Doc updates

#### Manual Testing Performed

- [x] Unit and acceptance tests 
- [x] Test in local dev env

#### Accessibility

NA

### Deployment

- [ ] `rake deploy:app[staging,document-updater,master,latest]`
- [ ] `rake deploy:app[production,document-updater,master,latest]`

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

@henryoswald 