### PR TITLE
remove the limit of 300 http sockets

### DIFF
--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -1,6 +1,3 @@
-const http = require('http')
-http.globalAgent.maxSockets = 300
-
 module.exports = {
   internal: {
     documentupdater: {


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

This PR removes an arbitrary limit on the number of sockets, `http.globalAgent.maxSockets = 300`, which might  cause docupdater to hang if was reached. 

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3621

### Review

Removes limit only

#### Potential Impact

Low under normal circumstances.

#### Manual Testing Performed

- [x] Unit and acceptance tests 
- [x] Test in local dev environment

#### Accessibility

NA


### Deployment

- [ ] `rake deploy:app[staging,document-updater,master,latest]`
- [ ] `rake deploy:app[production,document-updater,master,latest]`

#### Deployment Checklist

NA

#### Metrics and Monitoring

Active handles in the sockets dashboard

#### Who Needs to Know?

cc @henryoswald 