### PR TITLE
[misc] double down on enforcing doc size limits

### DIFF
--- a/app/js/RedisManager.js
+++ b/app/js/RedisManager.js
@@ -72,6 +72,13 @@ module.exports = RedisManager = {
       logger.error({ err: error, doc_id, docLines }, error.message)
       return callback(error)
     }
+    // Do a cheap size check on the serialized blob.
+    if (docLines.length > Settings.max_doc_length) {
+      const docSize = docLines.length
+      const err = new Error('blocking doc insert into redis: doc is too large')
+      logger.error({ project_id, doc_id, err, docSize }, err.message)
+      return callback(err)
+    }
     const docHash = RedisManager._computeHash(docLines)
     // record bytes sent to redis
     metrics.summary('redis.docLines', docLines.length, { status: 'set' })

--- a/app/js/RedisManager.js
+++ b/app/js/RedisManager.js
@@ -468,6 +468,13 @@ module.exports = RedisManager = {
         logger.error({ err: error, doc_id, newDocLines }, error.message)
         return callback(error)
       }
+      // Do a cheap size check on the serialized blob.
+      if (newDocLines.length > Settings.max_doc_length) {
+        const err = new Error('blocking doc update: doc is too large')
+        const docSize = newDocLines.length
+        logger.error({ project_id, doc_id, err, docSize }, err.message)
+        return callback(err)
+      }
       const newHash = RedisManager._computeHash(newDocLines)
 
       const opVersions = appliedOps.map((op) => (op != null ? op.v : undefined))

--- a/app/js/ShareJsUpdateManager.js
+++ b/app/js/ShareJsUpdateManager.js
@@ -87,6 +87,20 @@ module.exports = ShareJsUpdateManager = {
         if (error != null) {
           return callback(error)
         }
+        const docSizeAfter = data.snapshot.length
+        if (docSizeAfter > Settings.max_doc_length) {
+          const docSizeBefore = lines.join('\n').length
+          const err = new Error(
+            'blocking persistence of ShareJs update: doc size exceeds limits'
+          )
+          logger.error(
+            { project_id, doc_id, err, docSizeBefore, docSizeAfter },
+            err.message
+          )
+          metrics.inc('sharejs.other-error')
+          const publicError = 'Update takes doc over max doc size'
+          return callback(publicError)
+        }
         // only check hash when present and no other updates have been applied
         if (update.hash != null && incomingUpdateVersion === version) {
           const ourHash = ShareJsUpdateManager._computeHash(data.snapshot)

--- a/test/acceptance/js/SizeCheckTests.js
+++ b/test/acceptance/js/SizeCheckTests.js
@@ -1,0 +1,129 @@
+const { expect } = require('chai')
+const Settings = require('settings-sharelatex')
+
+const MockWebApi = require('./helpers/MockWebApi')
+const DocUpdaterClient = require('./helpers/DocUpdaterClient')
+const DocUpdaterApp = require('./helpers/DocUpdaterApp')
+
+describe('SizeChecks', function () {
+  before(function (done) {
+    DocUpdaterApp.ensureRunning(done)
+  })
+  beforeEach(function () {
+    this.version = 0
+    this.update = {
+      doc: this.doc_id,
+      op: [
+        {
+          i: 'insert some more lines that will bring it above the limit\n',
+          p: 42
+        }
+      ],
+      v: this.version
+    }
+    this.project_id = DocUpdaterClient.randomId()
+    this.doc_id = DocUpdaterClient.randomId()
+  })
+
+  describe('when a doc is above the doc size limit already', function () {
+    beforeEach(function () {
+      this.lines = ['0123456789'.repeat(Settings.max_doc_length / 10 + 1)]
+      MockWebApi.insertDoc(this.project_id, this.doc_id, {
+        lines: this.lines,
+        v: this.version
+      })
+    })
+
+    it('should error when fetching the doc', function (done) {
+      DocUpdaterClient.getDoc(this.project_id, this.doc_id, (error, res) => {
+        if (error) return done(error)
+        expect(res.statusCode).to.equal(500)
+        done()
+      })
+    })
+
+    describe('when trying to update', function () {
+      beforeEach(function (done) {
+        const update = {
+          doc: this.doc_id,
+          op: this.update.op,
+          v: this.version
+        }
+        DocUpdaterClient.sendUpdate(
+          this.project_id,
+          this.doc_id,
+          update,
+          (error) => {
+            if (error != null) {
+              throw error
+            }
+            setTimeout(done, 200)
+          }
+        )
+      })
+
+      it('should still error when fetching the doc', function (done) {
+        DocUpdaterClient.getDoc(this.project_id, this.doc_id, (error, res) => {
+          if (error) return done(error)
+          expect(res.statusCode).to.equal(500)
+          done()
+        })
+      })
+    })
+  })
+
+  describe('when a doc is just below the doc size limit', function () {
+    beforeEach(function () {
+      this.lines = ['0123456789'.repeat(Settings.max_doc_length / 10 - 1)]
+      MockWebApi.insertDoc(this.project_id, this.doc_id, {
+        lines: this.lines,
+        v: this.version
+      })
+    })
+
+    it('should be able to fetch the doc', function (done) {
+      DocUpdaterClient.getDoc(
+        this.project_id,
+        this.doc_id,
+        (error, res, doc) => {
+          if (error) return done(error)
+          expect(doc.lines).to.deep.equal(this.lines)
+          done()
+        }
+      )
+    })
+
+    describe('when trying to update', function () {
+      beforeEach(function (done) {
+        const update = {
+          doc: this.doc_id,
+          op: this.update.op,
+          v: this.version
+        }
+        DocUpdaterClient.sendUpdate(
+          this.project_id,
+          this.doc_id,
+          update,
+          (error) => {
+            if (error != null) {
+              throw error
+            }
+            setTimeout(done, 200)
+          }
+        )
+      })
+
+      it('should not update the doc', function (done) {
+        DocUpdaterClient.getDoc(
+          this.project_id,
+          this.doc_id,
+          (error, res, doc) => {
+            if (error) return done(error)
+            expect(doc.lines).to.deep.equal(this.lines)
+            done()
+          }
+        )
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/4195

This PR is adding additional size checks at key points in the processing pipeline of docs:
- before populating the doc into redis
- after updating a doc via ShareJs
- before persisting updates into redis

All these checks are cheap string size checks.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/4195

#### Potential Impact

High. The checks are on hot paths.

#### Review

It seems like the size check in ShareJS is broken as the code path added in ae1e8acf92c9e96121f40ab895f9c09e09611b6f is exercised by the tests.
https://github.com/overleaf/document-updater/blob/ecc7498720eca3f3b2a30c11d315c9491e49576b/app/js/sharejs/server/model.js#L202-L207

#### Manual Testing Performed

- run acceptance with verbose logging and see the new error messages

<details>

``` 
redis event: connect undefined
  SizeChecks
redis event: ready undefined
    when a doc is above the doc size limit already
{"name":"document-updater","hostname":"c64c9346b034","pid":31,"level":50,"project_id":"6358055c0265098f4dd84ac6","doc_id":"e20f3e5be3660e307f091919","err":{"message":"blocking doc insert into redis: doc is too large","name":"Error","stack":"Error: blocking doc insert into redis: doc is too large\n    at Object.putDocInMemory (/app/app/js/RedisManager.js:78:19)\n    at /app/app/js/DocumentManager.js:91:31\n    at callback (/app/app/js/PersistenceManager.js:69:14)\n    at Request.<anonymous> (/app/app/js/PersistenceManager.js:116:18)\n    at Request._callback (/app/node_modules/lodash/lodash.js:10076:25)\n    at Request.requestRetryReply [as reply] (/app/node_modules/requestretry/index.js:105:19)\n    at Request.<anonymous> (/app/node_modules/requestretry/index.js:146:10)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)","info":{}},"docSize":2097164,"msg":"blocking doc insert into redis: doc is too large","time":"2021-05-06T17:15:10.766Z","v":0}
{"name":"document-updater","hostname":"c64c9346b034","pid":31,"level":50,"err":{"message":"blocking doc insert into redis: doc is too large","name":"Error","stack":"Error: blocking doc insert into redis: doc is too large\n    at Object.putDocInMemory (/app/app/js/RedisManager.js:78:19)\n    at /app/app/js/DocumentManager.js:91:31\n    at callback (/app/app/js/PersistenceManager.js:69:14)\n    at Request.<anonymous> (/app/app/js/PersistenceManager.js:116:18)\n    at Request._callback (/app/node_modules/lodash/lodash.js:10076:25)\n    at Request.requestRetryReply [as reply] (/app/node_modules/requestretry/index.js:105:19)\n    at Request.<anonymous> (/app/node_modules/requestretry/index.js:146:10)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)","info":{}},"req":{"method":"GET","url":"/project/6358055c0265098f4dd84ac6/doc/e20f3e5be3660e307f091919","headers":{"host":"localhost:3003","connection":"close"},"remoteAddress":"127.0.0.1","remotePort":34910},"msg":"request errored","time":"2021-05-06T17:15:10.769Z","v":0}
      ✓ should error when fetching the doc (55ms)
      when trying to update
{"name":"document-updater","hostname":"c64c9346b034","pid":31,"level":50,"project_id":"2f722a0a354fb62286a1898d","doc_id":"31d8efd1f1e8a4d95d24e6e5","err":{"message":"blocking doc insert into redis: doc is too large","name":"Error","stack":"Error: blocking doc insert into redis: doc is too large\n    at Object.putDocInMemory (/app/app/js/RedisManager.js:78:19)\n    at /app/app/js/DocumentManager.js:91:31\n    at callback (/app/app/js/PersistenceManager.js:69:14)\n    at Request.<anonymous> (/app/app/js/PersistenceManager.js:116:18)\n    at Request._callback (/app/node_modules/lodash/lodash.js:10076:25)\n    at Request.requestRetryReply [as reply] (/app/node_modules/requestretry/index.js:105:19)\n    at Request.<anonymous> (/app/node_modules/requestretry/index.js:146:10)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)","info":{}},"docSize":2097164,"msg":"blocking doc insert into redis: doc is too large","time":"2021-05-06T17:15:10.803Z","v":0}
{"name":"document-updater","hostname":"c64c9346b034","pid":31,"level":50,"err":{"message":"blocking doc insert into redis: doc is too large","name":"Error","stack":"Error: blocking doc insert into redis: doc is too large\n    at Object.putDocInMemory (/app/app/js/RedisManager.js:78:19)\n    at /app/app/js/DocumentManager.js:91:31\n    at callback (/app/app/js/PersistenceManager.js:69:14)\n    at Request.<anonymous> (/app/app/js/PersistenceManager.js:116:18)\n    at Request._callback (/app/node_modules/lodash/lodash.js:10076:25)\n    at Request.requestRetryReply [as reply] (/app/node_modules/requestretry/index.js:105:19)\n    at Request.<anonymous> (/app/node_modules/requestretry/index.js:146:10)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)","info":{}},"project_id":"2f722a0a354fb62286a1898d","doc_id":"31d8efd1f1e8a4d95d24e6e5","msg":"error processing update","time":"2021-05-06T17:15:10.805Z","v":0}
{"name":"document-updater","hostname":"c64c9346b034","pid":31,"level":50,"project_id":"2f722a0a354fb62286a1898d","doc_id":"31d8efd1f1e8a4d95d24e6e5","err":{"message":"blocking doc insert into redis: doc is too large","name":"Error","stack":"Error: blocking doc insert into redis: doc is too large\n    at Object.putDocInMemory (/app/app/js/RedisManager.js:78:19)\n    at /app/app/js/DocumentManager.js:91:31\n    at callback (/app/app/js/PersistenceManager.js:69:14)\n    at Request.<anonymous> (/app/app/js/PersistenceManager.js:116:18)\n    at Request._callback (/app/node_modules/lodash/lodash.js:10076:25)\n    at Request.requestRetryReply [as reply] (/app/node_modules/requestretry/index.js:105:19)\n    at Request.<anonymous> (/app/node_modules/requestretry/index.js:146:10)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)","info":{}},"docSize":2097164,"msg":"blocking doc insert into redis: doc is too large","time":"2021-05-06T17:15:11.042Z","v":0}
{"name":"document-updater","hostname":"c64c9346b034","pid":31,"level":50,"err":{"message":"blocking doc insert into redis: doc is too large","name":"Error","stack":"Error: blocking doc insert into redis: doc is too large\n    at Object.putDocInMemory (/app/app/js/RedisManager.js:78:19)\n    at /app/app/js/DocumentManager.js:91:31\n    at callback (/app/app/js/PersistenceManager.js:69:14)\n    at Request.<anonymous> (/app/app/js/PersistenceManager.js:116:18)\n    at Request._callback (/app/node_modules/lodash/lodash.js:10076:25)\n    at Request.requestRetryReply [as reply] (/app/node_modules/requestretry/index.js:105:19)\n    at Request.<anonymous> (/app/node_modules/requestretry/index.js:146:10)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)","info":{}},"req":{"method":"GET","url":"/project/2f722a0a354fb62286a1898d/doc/31d8efd1f1e8a4d95d24e6e5","headers":{"host":"localhost:3003","connection":"close"},"remoteAddress":"127.0.0.1","remotePort":34916},"msg":"request errored","time":"2021-05-06T17:15:11.042Z","v":0}
        ✓ should still error when fetching the doc (68ms)
    when a doc is just below the doc size limit
      ✓ should be able to fetch the doc (48ms)
      when trying to update
{"name":"document-updater","hostname":"c64c9346b034","pid":31,"level":50,"project_id":"7e637f27cf93b6f611a08a87","doc_id":"cf0b49c2ff609d64d2a27cd6","err":{"message":"blocking persistence of ShareJs update: doc size exceeds limits","name":"Error","stack":"Error: blocking persistence of ShareJs update: doc size exceeds limits\n    at /app/app/js/ShareJsUpdateManager.js:93:23\n    at /app/app/js/sharejs/server/model.js:680:7\n    at load (/app/app/js/sharejs/server/model.js:365:14)\n    at Model.getSnapshot (/app/app/js/sharejs/server/model.js:679:5)\n    at /app/app/js/ShareJsUpdateManager.js:86:20\n    at /app/app/js/sharejs/server/model.js:717:15\n    at /app/app/js/sharejs/server/syncqueue.js:53:18\n    at /app/app/js/sharejs/server/model.js:256:11\n    at ShareJsDB._writeOp (/app/app/js/ShareJsDB.js:54:12)\n    at /app/app/js/sharejs/server/model.js:228:16\n    at getOps (/app/app/js/sharejs/server/model.js:651:16)\n    at /app/app/js/sharejs/server/model.js:151:14\n    at flush (/app/app/js/sharejs/server/syncqueue.js:48:12)\n    at Object.enqueue [as opQueue] (/app/app/js/sharejs/server/syncqueue.js:36:12)\n    at /app/app/js/sharejs/server/model.js:714:13\n    at processTicksAndRejections (internal/process/task_queues.js:79:11)","info":{}},"docSizeBefore":2097140,"docSizeAfter":2097198,"msg":"blocking persistence of ShareJs update: doc size exceeds limits","time":"2021-05-06T17:15:11.127Z","v":0}
{"name":"document-updater","hostname":"c64c9346b034","pid":31,"level":50,"err":"Update takes doc over max doc size","project_id":"7e637f27cf93b6f611a08a87","doc_id":"cf0b49c2ff609d64d2a27cd6","msg":"error processing update","time":"2021-05-06T17:15:11.127Z","v":0}
        ✓ should not update the doc (39ms)
``` 
</details>
