### PR TITLE
peek at docs without fetching from mongo

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,6 +53,7 @@ app.param('doc_id', (req, res, next, docId) => {
 })
 
 app.get('/project/:project_id/doc/:doc_id', HttpController.getDoc)
+app.get('/project/:project_id/doc/:doc_id/peek', HttpController.peekDoc)
 // temporarily keep the GET method for backwards compatibility
 app.get('/project/:project_id/doc', HttpController.getProjectDocsAndFlushIfOld)
 // will migrate to the POST method of get_and_flush_if_old instead

--- a/test/acceptance/js/PeekingADoc.js
+++ b/test/acceptance/js/PeekingADoc.js
@@ -1,0 +1,99 @@
+const sinon = require('sinon')
+const MockWebApi = require('./helpers/MockWebApi')
+const DocUpdaterClient = require('./helpers/DocUpdaterClient')
+const DocUpdaterApp = require('./helpers/DocUpdaterApp')
+
+describe('Peeking a document', function () {
+  before(function (done) {
+    this.lines = ['one', 'two', 'three']
+    this.version = 42
+    return DocUpdaterApp.ensureRunning(done)
+  })
+
+  describe('when the document is not loaded', function () {
+    before(function (done) {
+      this.project_id = DocUpdaterClient.randomId()
+      this.doc_id = DocUpdaterClient.randomId()
+      sinon.spy(MockWebApi, 'getDocument')
+
+      MockWebApi.insertDoc(this.project_id, this.doc_id, {
+        lines: this.lines,
+        version: this.version,
+      })
+
+      return DocUpdaterClient.peekDoc(
+        this.project_id,
+        this.doc_id,
+        (error, res, returnedDoc) => {
+          this.error = error
+          this.res = res
+          this.returnedDoc = returnedDoc
+          return done()
+        }
+      )
+    })
+
+    after(function () {
+      return MockWebApi.getDocument.restore()
+    })
+
+    it('should return a 404 response', function () {
+      this.res.statusCode.should.equal(404)
+    })
+
+    it('should not load the document from the web API', function () {
+      return MockWebApi.getDocument.called.should.equal(false)
+    })
+  })
+
+  describe('when the document is already loaded', function () {
+    before(function (done) {
+      this.project_id = DocUpdaterClient.randomId()
+      this.doc_id = DocUpdaterClient.randomId()
+
+      MockWebApi.insertDoc(this.project_id, this.doc_id, {
+        lines: this.lines,
+        version: this.version,
+      })
+      return DocUpdaterClient.preloadDoc(
+        this.project_id,
+        this.doc_id,
+        error => {
+          if (error != null) {
+            throw error
+          }
+          sinon.spy(MockWebApi, 'getDocument')
+          return DocUpdaterClient.getDoc(
+            this.project_id,
+            this.doc_id,
+            (error, res, returnedDoc) => {
+              this.res = res
+              this.returnedDoc = returnedDoc
+              return done()
+            }
+          )
+        }
+      )
+    })
+
+    after(function () {
+      return MockWebApi.getDocument.restore()
+    })
+
+    it('should return a 200 response', function () {
+      this.res.statusCode.should.equal(200)
+    })
+
+    it('should return the document lines', function () {
+      return this.returnedDoc.lines.should.deep.equal(this.lines)
+    })
+
+    it('should return the document version', function () {
+      return this.returnedDoc.version.should.equal(this.version)
+    })
+
+    it('should not load the document from the web API', function () {
+      return MockWebApi.getDocument.called.should.equal(false)
+    })
+  })
+})

--- a/test/acceptance/js/helpers/DocUpdaterClient.js
+++ b/test/acceptance/js/helpers/DocUpdaterClient.js
@@ -123,6 +123,18 @@ module.exports = DocUpdaterClient = {
     DocUpdaterClient.getDoc(projectId, docId, callback)
   },
 
+  peekDoc(projectId, docId, callback) {
+    request.get(
+      `http://localhost:3003/project/${projectId}/doc/${docId}/peek`,
+      (error, res, body) => {
+        if (body != null && res.statusCode >= 200 && res.statusCode < 300) {
+          body = JSON.parse(body)
+        }
+        callback(error, res, body)
+      }
+    )
+  },
+
   flushDoc(projectId, docId, callback) {
     request.post(
       `http://localhost:3003/project/${projectId}/doc/${docId}/flush`,

--- a/test/unit/js/HttpController/HttpControllerTests.js
+++ b/test/unit/js/HttpController/HttpControllerTests.js
@@ -14,6 +14,7 @@ describe('HttpController', function () {
         './ProjectManager': (this.ProjectManager = {}),
         './ProjectFlusher': { flushAllProjects() {} },
         './DeleteQueueManager': (this.DeleteQueueManager = {}),
+        './RedisManager': (this.RedisManager = {}),
         './Metrics': (this.Metrics = {}),
         './Errors': Errors,
       },


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

This PR adds a `peek` method to retrieve a doc from redis without fetching it from mongo.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/4539

Used by https://github.com/overleaf/track-changes/pull/117

### Review

This doesn't make any changes to the existing code paths.  It just adds a new `peekDoc` method which returns the doc from redis if present, and returns a 404 otherwise.

#### Potential Impact

Low

#### Manual Testing Performed

- [X] Acceptance tests
- [X]  Test in local dev env.  Note that peek only returns the document content and version, not the ops and ranges (since these aren't needed for the history migration).
```
$ curl -v localhost:3003/project/60f6a7329ccb0e0026fd1357/doc/60f6a7339ccb0e0026fd1359/peek
< HTTP/1.1 404 Not Found

$ curl -v localhost:3003/project/60f6a7329ccb0e0026fd1357/doc/60f6a7339ccb0e0026fd1359
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Content-Type: application/json; charset=utf-8
< Content-Length: 1163
< 
{"id":"60f6a7339ccb0e0026fd1359","lines":["\\documentclass{article}",....,"\\end{document}",""],"version":81,"ops":[],"ranges":{},"pathname":"/main.tex"}

$ curl -v localhost:3003/project/60f6a7329ccb0e0026fd1357/doc/60f6a7339ccb0e0026fd1359/peek
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Content-Type: application/json; charset=utf-8
< Content-Length: 1119

{"id":"60f6a7339ccb0e0026fd1359","lines":["\\documentclass{article}",...,"\\end{document}",""],"version":81}
```
#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

cc @aeaton-overleaf  @thomas- 